### PR TITLE
Release v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** demo, theme demos, one click import  
 **Requires at least:** 4.4  
 **Tested up to:** 4.9.1  
-**Stable tag:** 1.1.5  
+**Stable tag:** 1.1.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -55,6 +55,11 @@ https://wpastra.com/sites-suggestions/
 3. Import the demo.
 
 ## Changelog ##
+
+v1.1.6 - 18-January-2018
+* New: Added filter `astra_sites_xml_import_options` to change the XML import options.
+* Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
+* Fix: WooCommerce shop, checkout cart page ids not setting issue.
 
 v1.1.5 - 11-January-2018
 * New: Added SVG file support for importing the SVG images.

--- a/astra-sites.php
+++ b/astra-sites.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Starter Sites
  * Plugin URI: http://www.wpastra.com/pro/
  * Description: Import free sites build with Astra theme.
- * Version: 1.1.5
+ * Version: 1.1.6
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: astra-sites
@@ -19,7 +19,7 @@ if ( ! defined( 'ASTRA_SITES_NAME' ) ) {
 }
 
 if ( ! defined( 'ASTRA_SITES_VER' ) ) {
-	define( 'ASTRA_SITES_VER', '1.1.5' );
+	define( 'ASTRA_SITES_VER', '1.1.6' );
 }
 
 if ( ! defined( 'ASTRA_SITES_FILE' ) ) {

--- a/inc/classes/class-astra-sites-importer.php
+++ b/inc/classes/class-astra-sites-importer.php
@@ -88,6 +88,8 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 
 				$demo_data = self::get_astra_single_demo( $demo_api_uri );
 
+				update_option( 'astra_sites_import_data', $demo_data );
+
 				if ( is_wp_error( $demo_data ) ) {
 					wp_send_json_error( $demo_data->get_error_message() );
 				} else {
@@ -236,6 +238,7 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 				'astra-site-widgets-data'    => '',
 				'astra-site-customizer-data' => '',
 				'astra-site-options-data'    => '',
+				'astra-post-data-mapping'    => '',
 				'astra-site-wxr-path'        => '',
 				'astra-enabled-extensions'   => '',
 				'astra-custom-404'           => '',
@@ -278,6 +281,7 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 				$remote_args['astra-site-widgets-data']    = json_decode( $data['astra-site-widgets-data'] );
 				$remote_args['astra-site-customizer-data'] = $data['astra-site-customizer-data'];
 				$remote_args['astra-site-options-data']    = $data['astra-site-options-data'];
+				$remote_args['astra-post-data-mapping']    = $data['astra-post-data-mapping'];
 				$remote_args['astra-site-wxr-path']        = $data['astra-site-wxr-path'];
 				$remote_args['astra-enabled-extensions']   = $data['astra-enabled-extensions'];
 				$remote_args['astra-custom-404']           = $data['astra-custom-404'];

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -47,7 +47,9 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		public function __construct() {
 			add_action( 'astra_sites_after_plugin_activation', array( $this, 'astra_pro' ), 10, 2 );
 			add_action( 'astra_sites_import_start', array( $this, 'import_enabled_extension' ), 10, 2 );
-			add_action( 'astra_sites_import_start', array( $this, 'import_custom_404' ), 10, 2 );
+
+			// Post mapping.
+			add_action( 'astra_sites_image_import_complete', array( $this, 'start_post_mapping' ) );
 		}
 
 		/**
@@ -75,7 +77,6 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 					}
 				}
 			}
-
 		}
 
 		/**
@@ -109,6 +110,161 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 					Astra_Admin_Helper::update_admin_settings_option( '_astra_ext_enabled_extensions', $demo_data['astra-enabled-extensions'] );
 				}
 			}
+		}
+
+		/**
+		 * Start post meta mapping of Astra Addon
+		 *
+		 * @since 1.0.6
+		 *
+		 * @return null     If there is no import option data found.
+		 */
+		function start_post_mapping() {
+			$demo_data = get_option( 'astra_sites_import_data', array() );
+			if ( ! isset( $demo_data['astra-post-data-mapping'] ) ) {
+				return;
+			}
+
+			$post_type = 'astra-advanced-hook';
+			$posts     = ( isset( $demo_data['astra-post-data-mapping'][ $post_type ] ) ) ? $demo_data['astra-post-data-mapping'][ $post_type ] : array();
+			if ( ! empty( $posts ) ) {
+				foreach ( $posts as $key => $post ) {
+					$page = get_page_by_title( $post['post_title'], OBJECT, $post_type );
+					if ( is_object( $page ) ) {
+						self::update_location_rules( $page->ID, 'ast-advanced-hook-location', $post['mapping']['ast-advanced-hook-location'] );
+					}
+				}
+			}
+
+			$post_type = 'astra_adv_header';
+			$posts     = ( isset( $demo_data['astra-post-data-mapping'][ $post_type ] ) ) ? $demo_data['astra-post-data-mapping'][ $post_type ] : array();
+			if ( ! empty( $posts ) ) {
+				foreach ( $posts as $key => $post ) {
+					$page = get_page_by_title( $post['post_title'], OBJECT, $post_type );
+					if ( is_object( $page ) ) {
+
+						self::update_location_rules( $page->ID, 'ast-advanced-headers-location', $post['mapping']['ast-advanced-headers-location'] );
+						self::update_location_rules( $page->ID, 'ast-advanced-headers-exclusion', $post['mapping']['ast-advanced-headers-exclusion'] );
+						self::update_header_mapping( $page->ID, 'ast-advanced-headers-design', $post['mapping']['ast-advanced-headers-design'] );
+					}
+				}
+			}
+		}
+
+		/**
+		 * Update Header Mapping Data
+		 *
+		 * @since 1.0.6
+		 *
+		 * @param  int    $post_id     Post ID.
+		 * @param  string $meta_key Post meta key.
+		 * @param  array  $mapping  Mapping array.
+		 * @return void
+		 */
+		public static function update_header_mapping( $post_id, $meta_key, $mapping = array() ) {
+			$headers_old = get_post_meta( $post_id, $meta_key, true );
+			$headers_new = self::get_header_mapping( $headers_old, $mapping );
+			update_post_meta( $post_id, $meta_key, $headers_new );
+		}
+
+		/**
+		 * Update Location Rules
+		 *
+		 * @since 1.0.6
+		 *
+		 * @param  int    $post_id     Post ID.
+		 * @param  string $meta_key Post meta key.
+		 * @param  array  $mapping  Mapping array.
+		 * @return void
+		 */
+		public static function update_location_rules( $post_id = '', $meta_key = '', $mapping = array() ) {
+			$location_new = self::get_location_mappings( $mapping );
+			update_post_meta( $post_id, $meta_key, $location_new );
+		}
+
+		/**
+		 * Get mapping locations.
+		 *
+		 * @since 1.0.6
+		 *
+		 * @param  array $location Location data.
+		 * @return array            Location mapping data.
+		 */
+		public static function get_location_mappings( $location = array() ) {
+			if ( empty( $location ) ) {
+				return $location;
+			}
+
+			if ( ! isset( $location['specific'] ) || empty( $location['specific'] ) ) {
+				return $location;
+			}
+
+			$mapping = array();
+
+			if ( isset( $location['specific']['post'] ) ) {
+				foreach ( $location['specific']['post'] as $post_type => $old_post_data ) {
+					if ( is_array( $old_post_data ) ) {
+						foreach ( $old_post_data as $post_key => $post ) {
+							if ( $post_object = get_page_by_path( $post['slug'] ) ) {
+								$mapping[] = 'post-' . absint( $post_object->ID );
+							}
+						}
+					}
+				}
+			}
+
+			if ( isset( $location['specific']['tax'] ) ) {
+				foreach ( $location['specific']['tax'] as $taxonomy_type => $old_term_data ) {
+					if ( is_array( $old_term_data ) ) {
+						foreach ( $old_term_data as $term_key => $term_data ) {
+							$term = get_term_by( 'slug', $term_data['slug'], $taxonomy_type );
+							if ( is_object( $term ) ) {
+								$mapping[] = 'tax-' . absint( $term->term_id );
+							}
+						}
+					}
+				}
+			}
+
+			$location['specific'] = $mapping;
+
+			return $location;
+		}
+
+		/**
+		 * Get advanced header mapping data
+		 *
+		 * @since 1.0.6
+		 *
+		 * @param  array $headers_old  Header mapping stored data.
+		 * @param  array $headers_data Header mapping data.
+		 * @return array                Filtered header mapping data.
+		 */
+		public static function get_header_mapping( $headers_old = array(), $headers_data = array() ) {
+
+			// Set menu location by menu slug.
+			if ( isset( $headers_data['menus'] ) && ! empty( $headers_data['menus'] ) ) {
+				foreach ( $headers_data['menus'] as $header_option_name => $menu_data ) {
+					$term = get_term_by( 'slug', $menu_data['slug'], 'nav_menu' );
+					if ( is_object( $term ) ) {
+						$headers_old[ $header_option_name ] = $term->term_id;
+					}
+				}
+			}
+
+			// Set image ID & URL after importing these on website.
+			if ( isset( $headers_data['images'] ) && ! empty( $headers_data['images'] ) ) {
+				foreach ( $headers_data['images'] as $key => $image_data ) {
+					if ( isset( $image_data['image'] ) && ! empty( $image_data['image'] ) ) {
+						$downloaded_image = Astra_Sites_Image_Importer::get_instance()->import( $image_data['image'] );
+
+						$headers_old[ $image_data['key_map']['url'] ] = $downloaded_image['url'];
+						$headers_old[ $image_data['key_map']['id'] ]  = $downloaded_image['id'];
+					}
+				}
+			}
+
+			return $headers_old;
 		}
 
 	}

--- a/inc/importers/class-astra-site-options-import.php
+++ b/inc/importers/class-astra-site-options-import.php
@@ -83,10 +83,17 @@ class Astra_Site_Options_Import {
 			'_fl_builder_enabled_templates',
 
 			// Plugin: WooCommerce.
+			// Pages.
 			'woocommerce_shop_page_title',
 			'woocommerce_cart_page_title',
 			'woocommerce_checkout_page_title',
 			'woocommerce_myaccount_page_title',
+			'woocommerce_edit_address_page_title',
+			'woocommerce_view_order_page_title',
+			'woocommerce_change_password_page_title',
+			'woocommerce_logout_page_title',
+
+			// Categories.
 			'woocommerce_product_cat',
 		);
 	}
@@ -116,11 +123,18 @@ class Astra_Site_Options_Import {
 
 					switch ( $option_name ) {
 
-						// Set page ID by page Title.
+						// Set WooCommerce page ID by page Title.
 						case 'woocommerce_shop_page_title':
 						case 'woocommerce_cart_page_title':
 						case 'woocommerce_checkout_page_title':
 						case 'woocommerce_myaccount_page_title':
+						case 'woocommerce_edit_address_page_title':
+						case 'woocommerce_view_order_page_title':
+						case 'woocommerce_change_password_page_title':
+						case 'woocommerce_logout_page_title':
+								$this->update_woocommerce_page_id_by_option_value( $option_name, $option_value );
+							break;
+
 						case 'page_for_posts':
 						case 'page_on_front':
 								$this->update_page_id_by_option_value( $option_name, $option_value );
@@ -164,6 +178,20 @@ class Astra_Site_Options_Import {
 		if ( is_object( $page ) ) {
 			update_option( $option_name, $page->ID );
 		}
+	}
+
+	/**
+	 * Update WooCommerce page ids.
+	 *
+	 * @since 1.0.6
+	 *
+	 * @param  string $option_name  Option name.
+	 * @param  mixed  $option_value Option value.
+	 * @return void
+	 */
+	private function update_woocommerce_page_id_by_option_value( $option_name, $option_value ) {
+		$option_name = str_replace( '_title', '_id', $option_name );
+		$this->update_page_id_by_option_value( $option_name, $option_value );
 	}
 
 	/**

--- a/inc/importers/class-astra-sites-helper.php
+++ b/inc/importers/class-astra-sites-helper.php
@@ -245,7 +245,7 @@ if ( ! class_exists( 'Astra_Sites_Helper' ) ) :
 			if ( ! empty( $file ) ) {
 
 				// Set variables for storage, fix file filename for query strings.
-				preg_match( '/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file, $matches );
+				preg_match( '/[^\?]+\.(jpe?g|jpe|svg|gif|png)\b/i', $file, $matches );
 				$file_array         = array();
 				$file_array['name'] = basename( $matches[0] );
 

--- a/inc/importers/wxr-importer/class-astra-wxr-importer.php
+++ b/inc/importers/wxr-importer/class-astra-wxr-importer.php
@@ -208,9 +208,11 @@ class Astra_WXR_Importer {
 	 * @return object   Importer object.
 	 */
 	public function get_importer() {
-		$options  = array(
-			'fetch_attachments' => true,
-			'default_author'    => get_current_user_id(),
+		$options  = apply_filters(
+			'astra_sites_xml_import_options', array(
+				'fetch_attachments' => true,
+				'default_author'    => get_current_user_id(),
+			)
 		);
 		$importer = new WXR_Importer( $options );
 		$logger   = new WP_Importer_Logger_ServerSentEvents();

--- a/languages/astra-sites.pot
+++ b/languages/astra-sites.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Astra Starter Sites package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra Starter Sites 1.1.5\n"
+"Project-Id-Version: Astra Starter Sites 1.1.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/astra-sites\n"
-"POT-Creation-Date: 2018-01-11 06:38:47+00:00\n"
+"POT-Creation-Date: 2018-01-18 08:35:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -48,27 +48,27 @@ msgstr ""
 msgid "You have not \"customize\" access to import the Astra site."
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:104
+#: inc/classes/class-astra-sites-importer.php:106
 msgid "Request site API URL is empty. Try again!"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:127
+#: inc/classes/class-astra-sites-importer.php:129
 msgid "Customizer data is empty!"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:156
+#: inc/classes/class-astra-sites-importer.php:158
 msgid "There was an error downloading the XML file."
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:162
+#: inc/classes/class-astra-sites-importer.php:164
 msgid "Invalid site XML file!"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:184
+#: inc/classes/class-astra-sites-importer.php:186
 msgid "Site options are empty!"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer.php:206
+#: inc/classes/class-astra-sites-importer.php:208
 msgid "Widget data is empty!"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpastra.com/pro/
 Tags: demo, theme demos, one click import
 Requires at least: 4.4
 Tested up to: 4.9.1
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -55,6 +55,11 @@ https://wpastra.com/sites-suggestions/
 3. Import the demo.
 
 == Changelog ==
+
+v1.1.6 - 18-January-2018
+* New: Added filter `astra_sites_xml_import_options` to change the XML import options.
+* Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
+* Fix: WooCommerce shop, checkout cart page ids not setting issue.
 
 v1.1.5 - 11-January-2018
 * New: Added SVG file support for importing the SVG images.


### PR DESCRIPTION
```
* New: Added filter `astra_sites_xml_import_options` to change the XML import options.
* Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
* Fix: WooCommerce shop, checkout cart page ids not setting issue.
```