### PR TITLE
Release v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ https://wpastra.com/sites-suggestions/
 
 ## Changelog ##
 
-v1.1.6 - 18-January-2018
+v1.1.6 - 22-January-2018
 * New: Added filter `astra_sites_xml_import_options` to change the XML import options.
 * Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
 * Fix: WooCommerce shop, checkout cart page ids not setting issue.
+* Fix: After site import updated demo url from the nav menus.
 
 v1.1.5 - 11-January-2018
 * New: Added SVG file support for importing the SVG images.

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		 * @since 1.0.0
 		 * @return object initialized object of class.
 		 */
-		public static function instance() {
+		public static function get_instance() {
 			if ( ! isset( self::$instance ) ) {
 				self::$instance = new self;
 			}
@@ -47,9 +47,18 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		public function __construct() {
 			add_action( 'astra_sites_after_plugin_activation', array( $this, 'astra_pro' ), 10, 2 );
 			add_action( 'astra_sites_import_start', array( $this, 'import_enabled_extension' ), 10, 2 );
+		}
 
-			// Post mapping.
-			add_action( 'astra_sites_image_import_complete', array( $this, 'start_post_mapping' ) );
+		/**
+		 * Import
+		 *
+		 * @since 1.1.6
+		 * @return void
+		 */
+		public function import() {
+			Astra_Sites_Image_Importer::log( '---- Processing Mapping - for Astra Pro ----' );
+
+			self::start_post_mapping();
 		}
 
 		/**
@@ -120,6 +129,13 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		 * @return null     If there is no import option data found.
 		 */
 		function start_post_mapping() {
+=======
+		 * @since 1.1.6
+		 *
+		 * @return null     If there is no import option data found.
+		 */
+		public static function start_post_mapping() {
+>>>>>>> a3bfee7f4ff29ad46f830f1fc67a7e343e11c8ee
 			$demo_data = get_option( 'astra_sites_import_data', array() );
 			if ( ! isset( $demo_data['astra-post-data-mapping'] ) ) {
 				return;
@@ -154,14 +170,16 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		/**
 		 * Update Header Mapping Data
 		 *
-		 * @since 1.0.6
+		 * @since 1.1.6
 		 *
 		 * @param  int    $post_id     Post ID.
 		 * @param  string $meta_key Post meta key.
 		 * @param  array  $mapping  Mapping array.
 		 * @return void
 		 */
-		public static function update_header_mapping( $post_id, $meta_key, $mapping = array() ) {
+		public static function update_header_mapping( $post_id = '', $meta_key = '', $mapping = array() ) {
+			Astra_Sites_Image_Importer::log( 'Mapping "' . $meta_key . '" for ' . $post_id );
+
 			$headers_old = get_post_meta( $post_id, $meta_key, true );
 			$headers_new = self::get_header_mapping( $headers_old, $mapping );
 			update_post_meta( $post_id, $meta_key, $headers_new );
@@ -170,7 +188,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		/**
 		 * Update Location Rules
 		 *
-		 * @since 1.0.6
+		 * @since 1.1.6
 		 *
 		 * @param  int    $post_id     Post ID.
 		 * @param  string $meta_key Post meta key.
@@ -178,6 +196,8 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		 * @return void
 		 */
 		public static function update_location_rules( $post_id = '', $meta_key = '', $mapping = array() ) {
+			Astra_Sites_Image_Importer::log( 'Mapping "' . $meta_key . '" for ' . $post_id );
+
 			$location_new = self::get_location_mappings( $mapping );
 			update_post_meta( $post_id, $meta_key, $location_new );
 		}
@@ -185,7 +205,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		/**
 		 * Get mapping locations.
 		 *
-		 * @since 1.0.6
+		 * @since 1.1.6
 		 *
 		 * @param  array $location Location data.
 		 * @return array            Location mapping data.
@@ -234,7 +254,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		/**
 		 * Get advanced header mapping data
 		 *
-		 * @since 1.0.6
+		 * @since 1.1.6
 		 *
 		 * @param  array $headers_old  Header mapping stored data.
 		 * @param  array $headers_data Header mapping data.
@@ -270,8 +290,8 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 	}
 
 	/**
-	 * Kicking this off by calling 'instance()' method
+	 * Kicking this off by calling 'get_instance()' method
 	 */
-	Astra_Sites_Compatibility_Astra_Pro::instance();
+	Astra_Sites_Compatibility_Astra_Pro::get_instance();
 
 endif;

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -124,18 +124,11 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		/**
 		 * Start post meta mapping of Astra Addon
 		 *
-		 * @since 1.0.6
-		 *
-		 * @return null     If there is no import option data found.
-		 */
-		function start_post_mapping() {
-=======
 		 * @since 1.1.6
 		 *
 		 * @return null     If there is no import option data found.
 		 */
 		public static function start_post_mapping() {
->>>>>>> a3bfee7f4ff29ad46f830f1fc67a7e343e11c8ee
 			$demo_data = get_option( 'astra_sites_import_data', array() );
 			if ( ! isset( $demo_data['astra-post-data-mapping'] ) ) {
 				return;

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing-misc.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing-misc.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Misc batch import tasks.
+ *
+ * @package Astra Sites
+ * @since 1.1.6
+ */
+
+if ( ! class_exists( 'Astra_Sites_Batch_Processing_Misc' ) ) :
+
+	/**
+	 * Astra_Sites_Batch_Processing_Misc
+	 *
+	 * @since 1.1.6
+	 */
+	class Astra_Sites_Batch_Processing_Misc {
+
+		/**
+		 * Instance
+		 *
+		 * @since 1.1.6
+		 * @access private
+		 * @var object Class object.
+		 */
+		private static $instance;
+
+		/**
+		 * Initiator
+		 *
+		 * @since 1.1.6
+		 * @return object initialized object of class.
+		 */
+		public static function get_instance() {
+
+			if ( ! isset( self::$instance ) ) {
+				self::$instance = new self;
+			}
+			return self::$instance;
+		}
+
+		/**
+		 * Constructor
+		 *
+		 * @since 1.1.6
+		 */
+		public function __construct() {
+		}
+
+		/**
+		 * Import
+		 *
+		 * @since 1.1.6
+		 * @return void
+		 */
+		public function import() {
+
+			Astra_Sites_Image_Importer::log( '---- Processing MISC ----' );
+
+			self::fix_nav_menus();
+		}
+
+		/**
+		 * Import Module Images.
+		 *
+		 * @return object
+		 */
+		public static function fix_nav_menus() {
+			// Not found site data, then return.
+			$demo_data = get_option( 'astra_sites_import_data', array() );
+			if ( ! isset( $demo_data['astra-post-data-mapping'] ) ) {
+				return;
+			}
+
+			// Not found/empty XML URL, then return.
+			$xml_url = ( isset( $demo_data['astra-site-wxr-path'] ) ) ? esc_url( $demo_data['astra-site-wxr-path'] ) : '';
+			if ( empty( $xml_url ) ) {
+				return;
+			}
+
+			// Not empty site URL, then return.
+			$site_url = strpos( $xml_url, '/wp-content' );
+			if ( false === $site_url ) {
+				return;
+			}
+
+			// Get remote site URL.
+			$site_url = substr( $xml_url, 0, $site_url );
+
+			$post_ids = self::get_menu_post_ids();
+			if ( is_array( $post_ids ) ) {
+				foreach ( $post_ids as $post_id ) {
+					Astra_Sites_Image_Importer::log( 'Post ID: ' . $post_id );
+
+					$menu_url = get_post_meta( $post_id, '_menu_item_url', true );
+
+					if ( $menu_url ) {
+						$menu_url = str_replace( $site_url, site_url(), $menu_url );
+						update_post_meta( $post_id, '_menu_item_url', $menu_url );
+					}
+				}
+			}
+		}
+
+		/**
+		 * Get all post id's
+		 *
+		 * @since 1.1.6
+		 *
+		 * @return array
+		 */
+		public static function get_menu_post_ids() {
+
+			$args = array(
+				'post_type'     => 'nav_menu_item',
+
+				// Query performance optimization.
+				'fields'        => 'ids',
+				'no_found_rows' => true,
+				'post_status'   => 'any',
+			);
+
+			$query = new WP_Query( $args );
+
+			// Have posts?
+			if ( $query->have_posts() ) :
+
+				return $query->posts;
+
+			endif;
+			return null;
+		}
+
+	}
+
+	/**
+	 * Kicking this off by calling 'get_instance()' method
+	 */
+	Astra_Sites_Batch_Processing_Misc::get_instance();
+
+endif;

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing.php
@@ -68,8 +68,13 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing' ) ) :
 
 			// Prepare Widgets.
 			require_once ASTRA_SITES_DIR . 'inc/importers/batch-processing/class-astra-sites-batch-processing-widgets.php';
+
+			// Prepare Page Builders.
 			require_once ASTRA_SITES_DIR . 'inc/importers/batch-processing/class-astra-sites-batch-processing-beaver-builder.php';
 			require_once ASTRA_SITES_DIR . 'inc/importers/batch-processing/class-astra-sites-batch-processing-elementor.php';
+
+			// Prepare Misc.
+			require_once ASTRA_SITES_DIR . 'inc/importers/batch-processing/class-astra-sites-batch-processing-misc.php';
 
 			self::$process_all = new WP_Background_Process_Astra();
 
@@ -138,6 +143,18 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing' ) ) :
 				}
 			} else {
 				Astra_Sites_Image_Importer::log( 'Couldn\'t not import image due to allow_url_fopen() is disabled!' );
+			}
+
+			// Add "astra-addon" in import [queue].
+			if ( is_plugin_active( 'astra-addon/astra-addon.php' ) ) {
+				if ( class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) {
+					self::$process_all->push_to_queue( Astra_Sites_Compatibility_Astra_Pro::get_instance() );
+				}
+			}
+
+			// Add "misc" in import [queue].
+			if ( class_exists( 'Astra_Sites_Batch_Processing_Misc' ) ) {
+				self::$process_all->push_to_queue( Astra_Sites_Batch_Processing_Misc::get_instance() );
 			}
 
 			// Dispatch Queue.

--- a/inc/importers/class-astra-site-options-import.php
+++ b/inc/importers/class-astra-site-options-import.php
@@ -183,7 +183,7 @@ class Astra_Site_Options_Import {
 	/**
 	 * Update WooCommerce page ids.
 	 *
-	 * @since 1.0.6
+	 * @since 1.1.6
 	 *
 	 * @param  string $option_name  Option name.
 	 * @param  mixed  $option_value Option value.

--- a/readme.txt
+++ b/readme.txt
@@ -56,10 +56,11 @@ https://wpastra.com/sites-suggestions/
 
 == Changelog ==
 
-v1.1.6 - 18-January-2018
+v1.1.6 - 22-January-2018
 * New: Added filter `astra_sites_xml_import_options` to change the XML import options.
 * Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
 * Fix: WooCommerce shop, checkout cart page ids not setting issue.
+* Fix: After site import updated demo url from the nav menus.
 
 v1.1.5 - 11-January-2018
 * New: Added SVG file support for importing the SVG images.


### PR DESCRIPTION
- New: Added filter `astra_sites_xml_import_options` to change the XML import options.
- Fix: Astra Pro plugin 'Custom Layouts' & 'Page Headers' not setting right display location due to different page, tax, category ids.
- Fix: WooCommerce shop, checkout cart page ids not setting issue.
- Fix: After site import updated demo url from the nav menus.