### PR TITLE
Change the site type string from premium with agency.

### DIFF
--- a/inc/assets/css/admin.css
+++ b/inc/assets/css/admin.css
@@ -348,12 +348,6 @@ body.loading-content .select-page-builder {
     animation-name: bounce;
     -moz-animation-name: bounce;
 }
-.select-page-builder h3 {
-    margin:  0;
-    font-size: 2em;
-    display: flex;
-    align-items: baseline;
-}
 .select-page-builder {
     margin-left: 6em;
 }
@@ -363,9 +357,13 @@ body.loading-content .select-page-builder {
 }
 
 .select-page-builder h3 {
+    margin:  0;
+    font-size: 2em;
+    display: flex;
+    align-items: baseline;
     position: absolute;
     padding: 40px 0;
-    margin-left: 90px;
+    margin-left: 160px;
 }
 .select-page-builder {
     margin: -20px 0 0 -5px;

--- a/inc/assets/css/admin.css
+++ b/inc/assets/css/admin.css
@@ -329,11 +329,10 @@ body.loading-content .select-page-builder {
     -ms-transform: rotate(90deg);
     transform: rotate(90deg);
     display: inline-block;
-    font-size: 2.5em;
+    font-size: 1.5em;
     color: #797979;
     vertical-align: middle;
-    margin-right: 0.3em;
-    margin-bottom: 0.3em;
+    margin-right: 10px;
     -webkit-transition: all linear 0.6s;
     -moz-transition: all linear 0.6s;
     -ms-transition: all linear 0.6s;
@@ -352,6 +351,8 @@ body.loading-content .select-page-builder {
 .select-page-builder h3 {
     margin:  0;
     font-size: 2em;
+    display: flex;
+    align-items: baseline;
 }
 .select-page-builder {
     margin-left: 6em;

--- a/inc/assets/css/admin.css
+++ b/inc/assets/css/admin.css
@@ -363,7 +363,7 @@ body.loading-content .select-page-builder {
     align-items: baseline;
     position: absolute;
     padding: 40px 0;
-    margin-left: 160px;
+    margin-left: 170px;
 }
 .select-page-builder {
     margin: -20px 0 0 -5px;

--- a/inc/includes/admin-page.php
+++ b/inc/includes/admin-page.php
@@ -53,7 +53,10 @@ defined( 'ABSPATH' ) or exit;
 	</div>
 
 	<div class="select-page-builder">
-		<h3><span class="up-arrow">&#8626;</span><?php _e( 'Select Your Favorite Page Builder', 'astra-sites' ); ?></h3>
+		<h3>
+			<span class="up-arrow dashicons dashicons-editor-break"></span>
+			<span class="note"><?php _e( 'Select Your Favorite Page Builder', 'astra-sites' ); ?></span>
+		</h3>
 		<img src="<?php echo esc_url( ASTRA_SITES_URI . 'inc/assets/images/sites-screenshot.jpg' ); ?>" alt="<?php _e( 'Sites List..', 'astra-sites' ); ?>" title="<?php _e( 'Sites List..', 'astra-sites' ); ?>" />
 	</div>
 

--- a/inc/includes/admin-page.php
+++ b/inc/includes/admin-page.php
@@ -237,7 +237,8 @@ defined( 'ABSPATH' ) or exit;
 					</span>
 					<span class="more-details"> <?php esc_html_e( 'Details &amp; Preview', 'astra-sites' ); ?> </span>
 					<# if ( data.items[ key ]['astra-site-type'] ) { #>
-						<span class="site-type {{data.items[ key ]['astra-site-type']}}">{{data.items[ key ]['astra-site-type']}}</span>
+						<# var type = ( data.items[ key ]['astra-site-type'] !== 'premium' ) ? ( data.items[ key ]['astra-site-type'] ) : 'agency'; #>
+						<span class="site-type {{data.items[ key ]['astra-site-type']}}">{{ type }}</span>
 					<# } #>
 					<# if ( data.items[ key ].status ) { #>
 						<span class="status {{data.items[ key ].status}}">{{data.items[ key ].status}}</span>


### PR DESCRIPTION
- Used WordPress dashicon arrow instead of HTML entity in select page builder string.
- Change the site type string from `premium` with `agency`.