### PR TITLE
File handling and Astra Pro plugin cache fixes

### DIFF
--- a/inc/classes/class-astra-sites-importer-log.php
+++ b/inc/classes/class-astra-sites-importer-log.php
@@ -287,10 +287,10 @@ if ( ! class_exists( 'Astra_Sites_Importer_Log' ) ) :
 			if ( ! file_exists( $dir_info['path'] ) ) {
 
 				// Create the directory.
-				mkdir( $dir_info['path'] );
+				wp_mkdir_p( $dir_info['path'] );
 
 				// Add an index file for security.
-				file_put_contents( $dir_info['path'] . 'index.html', '' );
+				self::get_filesystem()->put_contents( $dir_info['path'] . 'index.html', '' );
 			}
 
 			return $dir_info;

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -287,8 +287,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		 * @since 1.2.3
 		 * @return void
 		 */
-		function clear_cache()
-		{
+		function clear_cache() {
 			if ( is_callable( 'Astra_Minify::refresh_assets' ) ) {
 				Astra_Minify::refresh_assets();
 			}

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -47,6 +47,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 		public function __construct() {
 			add_action( 'astra_sites_after_plugin_activation', array( $this, 'astra_pro' ), 10, 2 );
 			add_action( 'astra_sites_import_start', array( $this, 'import_enabled_extension' ), 10, 2 );
+			add_action( 'astra_sites_import_complete', array( $this, 'clear_cache' ) );
 		}
 
 		/**
@@ -280,6 +281,18 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 			return $headers_old;
 		}
 
+		/**
+		 * Clear Cache
+		 *
+		 * @since 1.2.3
+		 * @return void
+		 */
+		function clear_cache()
+		{
+			if ( is_callable( 'Astra_Minify::refresh_assets' ) ) {
+				Astra_Minify::refresh_assets();
+			}
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,10 @@ https://wpastra.com/sites-suggestions/
 
 == Changelog ==
 
+Unreleased
+* Fix: The log file was not created if server does not support the file handling functions.
+* Fix: Clear the Astra Pro plugin cache after site import.
+
 v1.2.2 - 26-March-2018
 * Fix: Correctly load the Elementor Pro 2.0 compatibility class for beta versions.
 


### PR DESCRIPTION
* Fix: Clear the Astra Pro plugin cache after site import.
* Improvement: The log file was not created if server does not support the file handling functions.
