### PR TITLE
Release v1.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 **Tags:** demo, theme demos, one click import  
 **Requires at least:** 4.4  
 **Requires PHP:** 5.3  
-**Tested up to:** 4.9.6  
-**Stable tag:** 1.2.5  
+**Tested up to:** 4.9.7  
+**Stable tag:** 1.2.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -56,6 +56,9 @@ https://wpastra.com/sites-suggestions/
 3. Import the demo.
 
 ## Changelog ##
+
+v1.2.6 - 9-July-2018
+* Fix: We have added `wp_slash` to normalize the Elementor post meta. Elementor have also normalize it. So, We have avoided `wp_slash` while importing sites.
 
 v1.2.5 - 5-July-2018
 * Fix: Normalize Elementor post meta by using `wp_slash` to avoid the unslashing data.

--- a/astra-sites.php
+++ b/astra-sites.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Starter Sites
  * Plugin URI: http://www.wpastra.com/pro/
  * Description: Import free sites build with Astra theme.
- * Version: 1.2.5
+ * Version: 1.2.6
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: astra-sites
@@ -19,7 +19,7 @@ if ( ! defined( 'ASTRA_SITES_NAME' ) ) {
 }
 
 if ( ! defined( 'ASTRA_SITES_VER' ) ) {
-	define( 'ASTRA_SITES_VER', '1.2.5' );
+	define( 'ASTRA_SITES_VER', '1.2.6' );
 }
 
 if ( ! defined( 'ASTRA_SITES_FILE' ) ) {

--- a/inc/importers/wxr-importer/class-astra-wxr-importer.php
+++ b/inc/importers/wxr-importer/class-astra-wxr-importer.php
@@ -69,50 +69,6 @@ class Astra_WXR_Importer {
 		add_action( 'wp_ajax_astra-wxr-import', array( $this, 'sse_import' ) );
 		add_filter( 'wxr_importer.pre_process.user', '__return_null' );
 
-		// Elementor Import Support.
-		add_filter( 'wp_import_post_meta', array( $this, 'import_post_meta' ) );
-		add_filter( 'wxr_importer.pre_process.post_meta', array( $this, 'pre_process_post_meta' ) );
-	}
-
-	/**
-	 * Process post meta before WP importer.
-	 *
-	 * Normalize Elementor post meta on import, We need the `wp_slash` in order
-	 * to avoid the unslashing during the `add_post_meta`.
-	 *
-	 * @since 1.2.5
-	 *
-	 * @param array $post_meta Post meta.
-	 * @return array Updated post meta.
-	 */
-	function import_post_meta( $post_meta ) {
-		foreach ( $post_meta as &$meta ) {
-			if ( '_elementor_data' === $meta['key'] ) {
-				$meta['value'] = wp_slash( $meta['value'] );
-				break;
-			}
-		}
-
-		return $post_meta;
-	}
-
-	/**
-	 * Process post meta before WXR importer.
-	 *
-	 * Normalize Elementor post meta on import with the new WP_importer, We need
-	 * the `wp_slash` in order to avoid the unslashing during the `add_post_meta`.
-	 *
-	 * @since 1.2.5
-	 *
-	 * @param array $post_meta Post meta.
-	 * @return array Updated post meta.
-	 */
-	function pre_process_post_meta( $post_meta ) {
-		if ( '_elementor_data' === $post_meta['key'] ) {
-			$post_meta['value'] = wp_slash( $post_meta['value'] );
-		}
-
-		return $post_meta;
 	}
 
 	/**

--- a/languages/astra-sites.pot
+++ b/languages/astra-sites.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Astra Starter Sites package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra Starter Sites 1.2.5\n"
+"Project-Id-Version: Astra Starter Sites 1.2.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/astra-sites\n"
-"POT-Creation-Date: 2018-07-05 09:52:11+00:00\n"
+"POT-Creation-Date: 2018-07-09 11:10:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -345,7 +345,7 @@ msgstr ""
 msgid "No Title"
 msgstr ""
 
-#: inc/importers/wxr-importer/class-astra-wxr-importer.php:239
+#: inc/importers/wxr-importer/class-astra-wxr-importer.php:195
 msgid "Import complete!"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://wpastra.com/pro/
 Tags: demo, theme demos, one click import
 Requires at least: 4.4
 Requires PHP: 5.3
-Tested up to: 4.9.6
-Stable tag: 1.2.5
+Tested up to: 4.9.7
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ https://wpastra.com/sites-suggestions/
 3. Import the demo.
 
 == Changelog ==
+
+v1.2.6 - 9-July-2018
+* Fix: We have added `wp_slash` to normalize the Elementor post meta. Elementor have also normalize it. So, We have avoided `wp_slash` while importing sites.
 
 v1.2.5 - 5-July-2018
 * Fix: Normalize Elementor post meta by using `wp_slash` to avoid the unslashing data.


### PR DESCRIPTION
* Fix: We have added `wp_slash` to normalize the Elementor post meta. Elementor have also normalize it. So, We have avoided `wp_slash` while importing sites.