### PR TITLE
 * Fix: After Import UAG - Post Grid categories do not retain issue fixed

### DIFF
--- a/astra-sites.php
+++ b/astra-sites.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Starter Sites – Elementor, Beaver Builder & Gutenberg Templates
  * Plugin URI: http://www.wpastra.com/pro/
  * Description: Import free sites build with Astra theme.
- * Version: 1.3.5.1
+ * Version: 1.3.6
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: astra-sites
@@ -19,7 +19,7 @@ if ( ! defined( 'ASTRA_SITES_NAME' ) ) {
 }
 
 if ( ! defined( 'ASTRA_SITES_VER' ) ) {
-	define( 'ASTRA_SITES_VER', '1.3.5.1' );
+	define( 'ASTRA_SITES_VER', '1.3.6' );
 }
 
 if ( ! defined( 'ASTRA_SITES_FILE' ) ) {

--- a/astra-sites.php
+++ b/astra-sites.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Starter Sites – Elementor, Beaver Builder & Gutenberg Templates
  * Plugin URI: http://www.wpastra.com/pro/
  * Description: Import free sites build with Astra theme.
- * Version: 1.3.5
+ * Version: 1.3.5.1
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: astra-sites
@@ -19,7 +19,7 @@ if ( ! defined( 'ASTRA_SITES_NAME' ) ) {
 }
 
 if ( ! defined( 'ASTRA_SITES_VER' ) ) {
-	define( 'ASTRA_SITES_VER', '1.3.5' );
+	define( 'ASTRA_SITES_VER', '1.3.5.1' );
 }
 
 if ( ! defined( 'ASTRA_SITES_FILE' ) ) {

--- a/inc/classes/class-astra-sites-importer-log.php
+++ b/inc/classes/class-astra-sites-importer-log.php
@@ -68,7 +68,8 @@ if ( ! class_exists( 'Astra_Sites_Importer_Log' ) ) :
 
 			// Get user credentials for WP file-system API.
 			$astra_sites_import = wp_nonce_url( admin_url( 'themes.php?page=astra-sites' ), 'astra-import' );
-			if ( false === ( $creds = request_filesystem_credentials( $astra_sites_import, '', false, false, null ) ) ) {
+			$creds              = request_filesystem_credentials( $astra_sites_import, '', false, false, null );
+			if ( false === $creds ) {
 				return;
 			}
 

--- a/inc/classes/class-astra-sites-importer.php
+++ b/inc/classes/class-astra-sites-importer.php
@@ -344,16 +344,17 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 			// default values.
 			$remote_args = array();
 			$defaults    = array(
-				'id'                         => '',
-				'astra-site-widgets-data'    => '',
-				'astra-site-customizer-data' => '',
-				'astra-site-options-data'    => '',
-				'astra-post-data-mapping'    => '',
-				'astra-site-wxr-path'        => '',
-				'astra-site-wpforms-path'    => '',
-				'astra-enabled-extensions'   => '',
-				'astra-custom-404'           => '',
-				'required-plugins'           => '',
+				'id'                          => '',
+				'astra-site-widgets-data'     => '',
+				'astra-site-customizer-data'  => '',
+				'astra-site-options-data'     => '',
+				'astra-post-data-mapping'     => '',
+				'astra-site-wxr-path'         => '',
+				'astra-site-wpforms-path'     => '',
+				'astra-enabled-extensions'    => '',
+				'astra-custom-404'            => '',
+				'required-plugins'            => '',
+				'astra-site-taxonomy-mapping' => '',
 			);
 
 			$api_args = apply_filters(
@@ -390,16 +391,17 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 			$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
 			if ( ! isset( $data['code'] ) ) {
-				$remote_args['id']                         = $data['id'];
-				$remote_args['astra-site-widgets-data']    = json_decode( $data['astra-site-widgets-data'] );
-				$remote_args['astra-site-customizer-data'] = $data['astra-site-customizer-data'];
-				$remote_args['astra-site-options-data']    = $data['astra-site-options-data'];
-				$remote_args['astra-post-data-mapping']    = $data['astra-post-data-mapping'];
-				$remote_args['astra-site-wxr-path']        = $data['astra-site-wxr-path'];
-				$remote_args['astra-site-wpforms-path']    = $data['astra-site-wpforms-path'];
-				$remote_args['astra-enabled-extensions']   = $data['astra-enabled-extensions'];
-				$remote_args['astra-custom-404']           = $data['astra-custom-404'];
-				$remote_args['required-plugins']           = $data['required-plugins'];
+				$remote_args['id']                          = $data['id'];
+				$remote_args['astra-site-widgets-data']     = json_decode( $data['astra-site-widgets-data'] );
+				$remote_args['astra-site-customizer-data']  = $data['astra-site-customizer-data'];
+				$remote_args['astra-site-options-data']     = $data['astra-site-options-data'];
+				$remote_args['astra-post-data-mapping']     = $data['astra-post-data-mapping'];
+				$remote_args['astra-site-wxr-path']         = $data['astra-site-wxr-path'];
+				$remote_args['astra-site-wpforms-path']     = $data['astra-site-wpforms-path'];
+				$remote_args['astra-enabled-extensions']    = $data['astra-enabled-extensions'];
+				$remote_args['astra-custom-404']            = $data['astra-custom-404'];
+				$remote_args['required-plugins']            = $data['required-plugins'];
+				$remote_args['astra-site-taxonomy-mapping'] = $data['astra-site-taxonomy-mapping'];
 			}
 
 			// Merge remote demo and defaults.

--- a/inc/classes/class-astra-sites-importer.php
+++ b/inc/classes/class-astra-sites-importer.php
@@ -240,7 +240,7 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 
 			if ( isset( $wxr_url ) ) {
 
-				Astra_Sites_Importer_Log::add( 'Importing from XML ' . $xml );
+				Astra_Sites_Importer_Log::add( 'Importing from XML ' . $wxr_url );
 
 				// Download XML file.
 				$xml_path = Astra_Sites_Helper::download_file( $wxr_url );
@@ -378,7 +378,7 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 			// API Call.
 			$response = wp_remote_get( $demo_api_uri, $api_args );
 
-			if ( is_wp_error( $response ) || ( isset( $response->status ) && 0 == $response->status ) ) {
+			if ( is_wp_error( $response ) || ( isset( $response->status ) && 0 === $response->status ) ) {
 				if ( isset( $response->status ) ) {
 					$data = json_decode( $response, true );
 				} else {
@@ -487,7 +487,7 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 						foreach ( $widgets as $widget_key => $widget_data ) {
 
 							if ( isset( $sidebars_widgets['wp_inactive_widgets'] ) ) {
-								if ( ! in_array( $widget_key, $sidebars_widgets['wp_inactive_widgets'] ) ) {
+								if ( ! in_array( $widget_key, $sidebars_widgets['wp_inactive_widgets'], true ) ) {
 									$sidebars_widgets['wp_inactive_widgets'][] = $widget_key;
 								}
 							}

--- a/inc/classes/class-astra-sites-page.php
+++ b/inc/classes/class-astra-sites-page.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 			}
 
 			?>
-			<div class="notice notice-info is-dismissible astra-sites-getting-started-notice"> 
+			<div class="notice notice-info is-dismissible astra-sites-getting-started-notice">
 				<?php /* translators: %1$s is the admin page URL, %2$s is product name. */ ?>
 				<p><?php printf( __( 'Thank you for choosing %1$s! Check the library of <a class="astra-sites-getting-started-btn" href="%2$s">ready starter sites here »</a>', 'astra-sites' ), $product_name, admin_url( 'themes.php?page=astra-sites' ) ); ?></p>
 			</div>
@@ -243,7 +243,7 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 		public function render( $action ) {
 
 			// Settings update message.
-			if ( isset( $_REQUEST['message'] ) && ( 'saved' == $_REQUEST['message'] || 'saved_ext' == $_REQUEST['message'] ) ) {
+			if ( isset( $_REQUEST['message'] ) && ( 'saved' === $_REQUEST['message'] || 'saved_ext' === $_REQUEST['message'] ) ) {
 				?>
 					<span id="message" class="notice notice-success is-dismissive"><p> <?php esc_html_e( 'Settings saved successfully.', 'astra-sites' ); ?> </p></span>
 				<?php
@@ -347,11 +347,11 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 
 						$url = $this->get_page_url( $slug );
 
-						if ( 'general' == $slug ) {
+						if ( 'general' === $slug ) {
 							update_option( 'astra_parent_page_url', $url );
 						}
 
-						$active = ( $slug == $action ) ? 'nav-tab-active' : '';
+						$active = ( $slug === $action ) ? 'nav-tab-active' : '';
 						?>
 							<a class='nav-tab <?php echo esc_attr( $active ); ?>' href='<?php echo esc_url( $url ); ?>'> <?php echo esc_html( $data['label'] ); ?> </a>
 					<?php } ?>

--- a/inc/classes/class-astra-sites-white-label.php
+++ b/inc/classes/class-astra-sites-white-label.php
@@ -141,7 +141,7 @@ if ( ! class_exists( 'Astra_Sites_White_Label' ) ) :
 			}
 
 			// Set White Labels.
-			if ( ASTRA_SITES_BASE == $plugin_file ) {
+			if ( ASTRA_SITES_BASE === $plugin_file ) {
 
 				$name        = Astra_Ext_White_Label_Markup::get_whitelabel_string( 'astra-sites', 'name' );
 				$description = Astra_Ext_White_Label_Markup::get_whitelabel_string( 'astra-sites', 'description' );

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -237,7 +237,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 */
 		public static function set_api_url() {
 
-			self::$api_url = apply_filters( 'astra_sites_api_url', 'http://nik-websitedemos.sharkz.in/wp-json/wp/v2/' );
+			self::$api_url = apply_filters( 'astra_sites_api_url', 'https://websitedemos.net/wp-json/wp/v2/' );
 
 		}
 

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 			$file_system  = Astra_Sites_Importer_Log::get_instance()->get_filesystem();
 
 			// If file system fails? Then take a backup in site option.
-			if ( false == $file_system->put_contents( $log_file, json_encode( $old_settings ), FS_CHMOD_FILE ) ) {
+			if ( false === $file_system->put_contents( $log_file, json_encode( $old_settings ), FS_CHMOD_FILE ) ) {
 				update_option( 'astra_sites_' . $file_name, $old_settings );
 			}
 
@@ -178,13 +178,13 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 			$theme = wp_get_theme();
 
 			// Theme installed and activate.
-			if ( 'Astra' == $theme->name || 'Astra' == $theme->parent_theme ) {
+			if ( 'Astra' === $theme->name || 'Astra' === $theme->parent_theme ) {
 				return 'installed-and-active';
 			}
 
 			// Theme installed but not activate.
 			foreach ( (array) wp_get_themes() as $theme_dir => $theme ) {
-				if ( 'Astra' == $theme->name || 'Astra' == $theme->parent_theme ) {
+				if ( 'Astra' === $theme->name || 'Astra' === $theme->parent_theme ) {
 					return 'installed-but-inactive';
 				}
 			}

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -236,8 +236,8 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 * @since  1.0.0
 		 */
 		public static function set_api_url() {
-
-			self::$api_url = apply_filters( 'astra_sites_api_url', 'https://websitedemos.net/wp-json/wp/v2/' );
+			vl('nik'); //wp_die();
+			self::$api_url = apply_filters( 'astra_sites_api_url', 'http://nik-websitedemos.sharkz.in/wp-json/wp/v2/' );
 
 		}
 

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -237,7 +237,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 */
 		public static function set_api_url() {
 
-			self::$api_url = apply_filters( 'astra_sites_api_url', 'https://websitedemos.net/wp-json/wp/v2/' );
+			self::$api_url = apply_filters( 'astra_sites_api_url', 'http://nik-websitedemos.sharkz.in/wp-json/wp/v2/' );
 
 		}
 

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -236,8 +236,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 * @since  1.0.0
 		 */
 		public static function set_api_url() {
-			vl('nik'); //wp_die();
-			self::$api_url = apply_filters( 'astra_sites_api_url', 'http://nik-websitedemos.sharkz.in/wp-json/wp/v2/' );
+			self::$api_url = apply_filters( 'astra_sites_api_url', 'https://websitedemos.net/wp-json/wp/v2/' );
 
 		}
 

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -216,7 +216,7 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 				foreach ( $location['specific']['post'] as $post_type => $old_post_data ) {
 					if ( is_array( $old_post_data ) ) {
 						foreach ( $old_post_data as $post_key => $post ) {
-							$post_object = get_page_by_path( $post['slug'] )
+							$post_object = get_page_by_path( $post['slug'] );
 							if ( $post_object ) {
 								$mapping[] = 'post-' . absint( $post_object->ID );
 							}

--- a/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
+++ b/inc/classes/compatibility/astra-pro/class-astra-sites-compatibility-astra-pro.php
@@ -216,7 +216,8 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_Astra_Pro' ) ) :
 				foreach ( $location['specific']['post'] as $post_type => $old_post_data ) {
 					if ( is_array( $old_post_data ) ) {
 						foreach ( $old_post_data as $post_key => $post ) {
-							if ( $post_object = get_page_by_path( $post['slug'] ) ) {
+							$post_object = get_page_by_path( $post['slug'] )
+							if ( $post_object ) {
 								$mapping[] = 'post-' . absint( $post_object->ID );
 							}
 						}

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
@@ -107,26 +107,26 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing_Gutenberg' ) ) :
 
 			$ids_mapping = get_option( 'astra_sites_wpforms_ids_mapping', array() );
 
-			// Empty mapping? Then return.
-			if ( empty( $ids_mapping ) ) {
-				return;
-			}
-
 			// Post content.
 			$content = get_post_field( 'post_content', $post_id );
 
-			// Replace ID's.
-			foreach ( $ids_mapping as $old_id => $new_id ) {
-				$content = str_replace( '[wpforms id="' . $old_id, '[wpforms id="' . $new_id, $content );
+			if ( ! empty( $ids_mapping ) ) {
+				// Replace ID's.
+				foreach ( $ids_mapping as $old_id => $new_id ) {
+					$content = str_replace( '[wpforms id="' . $old_id, '[wpforms id="' . $new_id, $content );
+				}
 			}
 
 			// This replaces the category ID in UAG Post blocks.
 			$site_options = get_option( 'astra_sites_import_data', array() );
+
 			if ( isset( $site_options['astra-site-taxonomy-mapping'] ) ) {
+
 				$tax_mapping = $site_options['astra-site-taxonomy-mapping'];
 
 				if ( isset( $tax_mapping['post'] ) ) {
-					$catogory_mapping = $tax_mapping['post']['category'];
+
+					$catogory_mapping = ( isset( $tax_mapping['post']['category'] ) ) ? $tax_mapping['post']['category'] : array();
 
 					if ( is_array( $catogory_mapping ) ) {
 

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
@@ -120,6 +120,25 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing_Gutenberg' ) ) :
 				$content = str_replace( '[wpforms id="' . $old_id, '[wpforms id="' . $new_id, $content );
 			}
 
+			// This replaces the category ID in UAG Post blocks.
+			$site_options = get_option( 'astra_sites_import_data', array() );
+			if ( isset( $site_options['astra-site-taxonomy-mapping'] ) ) {
+				$tax_mapping = $site_options['astra-site-taxonomy-mapping'];
+
+				if ( isset( $tax_mapping['post'] ) ) {
+					$catogory_mapping = $tax_mapping['post']['category'];
+
+					if ( is_array( $catogory_mapping ) ) {
+
+						foreach ( $catogory_mapping as $key => $value ) {
+
+							$this_site_term = get_term_by( 'slug', $value['slug'], 'category' );
+							$content        = str_replace( '"categories":"' . $value['id'], '"categories":"' . $this_site_term->term_id, $content );
+						}
+					}
+				}
+			}
+
 			// # Tweak
 			// Gutenberg break block markup from render. Because the '&' is updated in database with '&amp;' and it
 			// expects as 'u0026amp;'. So, Converted '&amp;' with 'u0026amp;'.

--- a/inc/importers/class-astra-site-options-import.php
+++ b/inc/importers/class-astra-site-options-import.php
@@ -129,7 +129,7 @@ class Astra_Site_Options_Import {
 			if ( null !== $option_value ) {
 
 				// Is option exist in defined array site_options()?
-				if ( in_array( $option_name, self::site_options() ) ) {
+				if ( in_array( $option_name, self::site_options(), true ) ) {
 
 					switch ( $option_name ) {
 

--- a/inc/importers/class-astra-sites-helper.php
+++ b/inc/importers/class-astra-sites-helper.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'Astra_Sites_Helper' ) ) :
 
 					// Found slug in current menu list.
 					if ( isset( $widget->nav_menu ) ) {
-						$menu_id = array_search( $widget->nav_menu, $menu_locations );
+						$menu_id = array_search( $widget->nav_menu, $menu_locations, true );
 						if ( ! empty( $menu_id ) ) {
 							$all_sidebars->$widgets_key->$widget_key->nav_menu = $menu_id;
 						}

--- a/inc/importers/wxr-importer/class-astra-wxr-importer.php
+++ b/inc/importers/wxr-importer/class-astra-wxr-importer.php
@@ -161,13 +161,13 @@ class Astra_WXR_Importer {
 	function real_mimes( $defaults, $filename ) {
 
 		// Set EXT and real MIME type only for the file name `wxr.xml`.
-		if ( 'wxr.xml' == $filename ) {
+		if ( 'wxr.xml' === $filename ) {
 			$defaults['ext']  = 'xml';
 			$defaults['type'] = 'text/xml';
 		}
 
 		// Set EXT and real MIME type only for the file name `wpforms.json`.
-		if ( 'wpforms.json' == $filename ) {
+		if ( 'wpforms.json' === $filename ) {
 			$defaults['ext']  = 'json';
 			$defaults['type'] = 'text/plain';
 		}

--- a/languages/astra-sites.pot
+++ b/languages/astra-sites.pot
@@ -3,9 +3,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Astra Starter Sites – Elementor, Beaver Builder & "
-"Gutenberg Templates 1.3.5\n"
+"Gutenberg Templates 1.3.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/astra-sites\n"
-"POT-Creation-Date: 2019-04-18 06:55:00+00:00\n"
+"POT-Creation-Date: 2019-04-19 10:24:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -23,27 +23,27 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
-"X-Generator: grunt-wp-i18n1.0.0\n"
+"X-Generator: grunt-wp-i18n 1.0.3\n"
 
 #: astra-sites.php:18
 msgid "Astra Sites"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:254
+#: inc/classes/class-astra-sites-importer-log.php:255
 msgid "Enabled"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:257
+#: inc/classes/class-astra-sites-importer-log.php:258
 msgid "Disabled"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:342
-#: inc/classes/class-astra-sites-importer-log.php:399
+#: inc/classes/class-astra-sites-importer-log.php:343
+#: inc/classes/class-astra-sites-importer-log.php:400
 msgid "Yes"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:345
-#: inc/classes/class-astra-sites-importer-log.php:402
+#: inc/classes/class-astra-sites-importer-log.php:346
+#: inc/classes/class-astra-sites-importer-log.php:403
 msgid "No"
 msgstr ""
 
@@ -177,39 +177,39 @@ msgstr ""
 msgid "See Library"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:263
+#: inc/classes/class-astra-sites.php:262
 msgid "Installed! Activating.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:264
+#: inc/classes/class-astra-sites.php:263
 msgid "Activating.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:265
+#: inc/classes/class-astra-sites.php:264
 msgid "Activated! Reloading.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:266
+#: inc/classes/class-astra-sites.php:265
 msgid "Installing.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:299
+#: inc/classes/class-astra-sites.php:298
 msgid "Page Builder"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:304
+#: inc/classes/class-astra-sites.php:303
 msgid "Categories"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:345
+#: inc/classes/class-astra-sites.php:344
 msgid "Get Agency Bundle"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:347
+#: inc/classes/class-astra-sites.php:346
 msgid "Upgrade"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:354
+#: inc/classes/class-astra-sites.php:353
 #. translators: %s are HTML tags.
 msgid ""
 "%1$sRequired XMLReader PHP extension is missing on your server!%2$sAstra "
@@ -218,201 +218,201 @@ msgid ""
 "XMLReader PHP extension."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:355
+#: inc/classes/class-astra-sites.php:354
 msgid ""
 "Warning! Astra Site Import process is not complete. Don't close the window "
 "until import process complete. Do you still want to leave the window?"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:356
+#: inc/classes/class-astra-sites.php:355
 msgid "Error!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:357
+#: inc/classes/class-astra-sites.php:356
 msgid "Error! Read Possibilities."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:359
+#: inc/classes/class-astra-sites.php:358
 msgid "Done! View Site"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:360
+#: inc/classes/class-astra-sites.php:359
 msgid "Activating"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:361
+#: inc/classes/class-astra-sites.php:360
 msgid "Active"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:362
+#: inc/classes/class-astra-sites.php:361
 msgid "Import failed."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:363
+#: inc/classes/class-astra-sites.php:362
 msgid "Import failed. See error log."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:364
+#: inc/classes/class-astra-sites.php:363
 msgid "Import This Site"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:365 inc/classes/class-astra-sites.php:381
+#: inc/classes/class-astra-sites.php:364 inc/classes/class-astra-sites.php:380
 msgid "Importing.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:366 inc/includes/admin-page.php:161
+#: inc/classes/class-astra-sites.php:365 inc/includes/admin-page.php:161
 msgid "Read more"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:367
+#: inc/classes/class-astra-sites.php:366
 msgid "Hide"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:368
+#: inc/classes/class-astra-sites.php:367
 msgid "There was a problem receiving a response from server."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:369 inc/includes/admin-page.php:391
+#: inc/classes/class-astra-sites.php:368 inc/includes/admin-page.php:391
 msgid "No Demos found, Try a different search."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:372
+#: inc/classes/class-astra-sites.php:371
 msgid "Installing plugin "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:373
+#: inc/classes/class-astra-sites.php:372
 msgid "Plugin installed!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:374
+#: inc/classes/class-astra-sites.php:373
 msgid "Activating plugin "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:375
+#: inc/classes/class-astra-sites.php:374
 msgid "Plugin activated "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:376
+#: inc/classes/class-astra-sites.php:375
 msgid "Bulk plugin activation..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:377
+#: inc/classes/class-astra-sites.php:376
 msgid "Plugin activate - "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:378
+#: inc/classes/class-astra-sites.php:377
 msgid "Error! While activating plugin  - "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:379
+#: inc/classes/class-astra-sites.php:378
 msgid "Bulk plugin installation..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:380
+#: inc/classes/class-astra-sites.php:379
 msgid "Site API "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:382
+#: inc/classes/class-astra-sites.php:381
 msgid "Processing requests..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:383
+#: inc/classes/class-astra-sites.php:382
 msgid "Importing \"Customizer Settings\"..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:384
+#: inc/classes/class-astra-sites.php:383
 msgid "Imported customizer settings!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:385
+#: inc/classes/class-astra-sites.php:384
 msgid "Importing \"Contact Forms\"..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:386
+#: inc/classes/class-astra-sites.php:385
 msgid "Imported Contact Forms!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:387
+#: inc/classes/class-astra-sites.php:386
 msgid "Preparing \"XML\" Data..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:388
+#: inc/classes/class-astra-sites.php:387
 msgid "Set XML data!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:389
+#: inc/classes/class-astra-sites.php:388
 msgid "Importing \"XML\"..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:390
+#: inc/classes/class-astra-sites.php:389
 msgid "Imported XML!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:391
+#: inc/classes/class-astra-sites.php:390
 msgid "Importing \"Options\"..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:392
+#: inc/classes/class-astra-sites.php:391
 msgid "Imported Options!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:393
+#: inc/classes/class-astra-sites.php:392
 msgid "Importing \"Widgets\"..."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:394
+#: inc/classes/class-astra-sites.php:393
 msgid "Imported Widgets!"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:396
+#: inc/classes/class-astra-sites.php:395
 msgid "View site: "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:397
+#: inc/classes/class-astra-sites.php:396
 msgid "Getting Site Information.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:398
+#: inc/classes/class-astra-sites.php:397
 msgid "Importing Customizer Settings.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:399
+#: inc/classes/class-astra-sites.php:398
 msgid "Importing Contact Forms.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:400
+#: inc/classes/class-astra-sites.php:399
 msgid "Setting up import data.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:401
+#: inc/classes/class-astra-sites.php:400
 msgid "Importing Content.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:402
+#: inc/classes/class-astra-sites.php:401
 msgid "Importing Site Options.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:403
+#: inc/classes/class-astra-sites.php:402
 msgid "Importing Widgets.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:404
+#: inc/classes/class-astra-sites.php:403
 msgid "Import Complete.."
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:405
+#: inc/classes/class-astra-sites.php:404
 msgid "Previewing "
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:406
+#: inc/classes/class-astra-sites.php:405
 msgid "See Error Log &rarr;"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:440
+#: inc/classes/class-astra-sites.php:439
 msgid "No plugin specified"
 msgstr ""
 
-#: inc/classes/class-astra-sites.php:469
+#: inc/classes/class-astra-sites.php:468
 msgid "Plugin Activated"
 msgstr ""
 
@@ -816,13 +816,13 @@ msgstr ""
 msgid "http://www.brainstormforce.com"
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:275
+#: inc/classes/class-astra-sites-importer-log.php:276
 #. translators: %1$s Memory Limit, %2$s Recommended memory limit.
 msgctxt "Recommended Memory Limit"
 msgid "Current memory limit %1$s. We recommend setting memory to at least %2$s."
 msgstr ""
 
-#: inc/classes/class-astra-sites-importer-log.php:356
+#: inc/classes/class-astra-sites-importer-log.php:357
 msgctxt "PHP Version"
 msgid "We recommend to use php 5.4 or higher"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-sites",
-  "version": "1.3.5.1",
+  "version": "1.3.6",
   "main": "Gruntfile.js",
   "author": "Import Astra Starter Sites with just one click.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-sites",
-  "version": "1.3.5",
+  "version": "1.3.5.1",
   "main": "Gruntfile.js",
   "author": "Import Astra Starter Sites with just one click.",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://wpastra.com/pro/
 Tags: Elementor,Beaver Builder,Templates,Gutenberg,Astra Starter Sites
 Requires at least: 4.4
 Requires PHP: 5.3
-Tested up to: 5.1
-Stable tag: 1.3.5.1
+Tested up to: 5.1.1
+Stable tag: 1.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -116,6 +116,9 @@ We are open to suggestions and would love to work on topics that our users are l
 3. Click the import site button to start the import process.
 
 == Changelog ==
+
+v1.3.6 - 19-April-2019
+- Fix: After Import UAG - Post Grid categories do not retain issue fixed
 
 v1.3.5 - 17-April-2019
 - Improvement: Updated page builder selection screen UI.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Elementor,Beaver Builder,Templates,Gutenberg,Astra Starter Sites
 Requires at least: 4.4
 Requires PHP: 5.3
 Tested up to: 5.1
-Stable tag: 1.3.5
+Stable tag: 1.3.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Test Case - 

1) Assigned Category (say "Travel") to UAG  Post Grid block.
2) Import the website.
3) The Page containing this block did not have the category ("Travel") retained.