### PR TITLE
Change timeout for downloading the XML file

### DIFF
--- a/inc/importers/class-astra-sites-helper.php
+++ b/inc/importers/class-astra-sites-helper.php
@@ -159,6 +159,7 @@ if ( ! class_exists( 'Astra_Sites_Helper' ) ) :
 		 * Download File Into Uploads Directory
 		 *
 		 * @param  string $file Download File URL.
+		 * @param  int    $timeout_seconds Timeout in downloading the XML file in seconds.
 		 * @return array        Downloaded file data.
 		 */
 		public static function download_file( $file = '', $timeout_seconds = 300 ) {

--- a/inc/importers/class-astra-sites-helper.php
+++ b/inc/importers/class-astra-sites-helper.php
@@ -161,12 +161,10 @@ if ( ! class_exists( 'Astra_Sites_Helper' ) ) :
 		 * @param  string $file Download File URL.
 		 * @return array        Downloaded file data.
 		 */
-		public static function download_file( $file = '' ) {
+		public static function download_file( $file = '', $timeout_seconds = 300 ) {
 
 			// Gives us access to the download_url() and wp_handle_sideload() functions.
 			require_once( ABSPATH . 'wp-admin/includes/file.php' );
-
-			$timeout_seconds = 5;
 
 			// Download file to temp dir.
 			$temp_file = download_url( $file, $timeout_seconds );


### PR DESCRIPTION
Restores the timeout time to be 300 seconds which is the default for `download_url()`