### PR TITLE
Release v1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.3  
 **Tested up to:** 5.2  
-**Stable tag:** 1.4.2  
+**Stable tag:** 1.4.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -116,6 +116,12 @@ We are open to suggestions and would love to work on topics that our users are l
 3. Click the import site button to start the import process.
 
 ## Changelog ##
+
+v1.4.3 - 7-November-2019
+- Fix: Installing premium plugin from the WP CLI import.
+- Fix: WP CLI command `wp astra-sites list` showing the old result.
+- Fix: PHP error Astra_Sites_Batch_Processing_Elementor does not exist from WP CLI import.
+- Improvement: Some Elementor templates broken due to the missing wp_slash() from WP CLI import.
 
 v1.4.2 - 4-November-2019
 - Fix: Correctly added nonce to allow notice to be dismissed.

--- a/astra-sites.php
+++ b/astra-sites.php
@@ -3,7 +3,7 @@
  * Plugin Name: Astra Starter Sites
  * Plugin URI: http://www.wpastra.com/pro/
  * Description: Import free sites build with Astra theme.
- * Version: 1.4.2
+ * Version: 1.4.3
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: astra-sites
@@ -19,7 +19,7 @@ if ( ! defined( 'ASTRA_SITES_NAME' ) ) {
 }
 
 if ( ! defined( 'ASTRA_SITES_VER' ) ) {
-	define( 'ASTRA_SITES_VER', '1.4.2' );
+	define( 'ASTRA_SITES_VER', '1.4.3' );
 }
 
 if ( ! defined( 'ASTRA_SITES_FILE' ) ) {

--- a/inc/classes/class-astra-sites-importer.php
+++ b/inc/classes/class-astra-sites-importer.php
@@ -620,11 +620,6 @@ if ( ! class_exists( 'Astra_Sites_Importer' ) ) :
 		 */
 		public function clear_cache() {
 
-			// Clear 'Elementor' file cache.
-			if ( class_exists( '\Elementor\Plugin' ) ) {
-				Elementor\Plugin::$instance->posts_css_manager->clear_cache();
-			}
-
 			// Clear 'Builder Builder' cache.
 			if ( is_callable( 'FLBuilderModel::delete_asset_cache_for_all_posts' ) ) {
 				FLBuilderModel::delete_asset_cache_for_all_posts();

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -686,6 +686,9 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 
 			return false;
 		}
+
+
+
 	}
 
 	/**

--- a/inc/classes/compatibility/class-astra-sites-compatibility.php
+++ b/inc/classes/compatibility/class-astra-sites-compatibility.php
@@ -55,6 +55,9 @@ if ( ! class_exists( 'Astra_Sites_Compatibility' ) ) :
 
 			// Plugin - LearnDash LMS.
 			require_once ASTRA_SITES_DIR . 'inc/classes/compatibility/sfwd-lms/class-astra-sites-compatibility-sfwd-lms.php';
+
+			// Plugin - Elementor.
+			require_once ASTRA_SITES_DIR . 'inc/classes/compatibility/elementor/class-astra-sites-compatibility-elementor.php';
 		}
 
 	}

--- a/inc/classes/compatibility/elementor/class-astra-sites-compatibility-elementor.php
+++ b/inc/classes/compatibility/elementor/class-astra-sites-compatibility-elementor.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Astra Sites Compatibility for 'Elementor'
+ *
+ * @see  https://wordpress.org/plugins/elementor/
+ *
+ * @package Astra Sites
+ * @since 1.4.3
+ */
+
+if ( ! class_exists( 'Astra_Sites_Compatibility_Elementor' ) ) :
+
+	/**
+	 * Astra_Sites_Compatibility_Elementor
+	 *
+	 * @since 1.4.3
+	 */
+	class Astra_Sites_Compatibility_Elementor {
+
+		/**
+		 * Instance
+		 *
+		 * @access private
+		 * @var object Class object.
+		 * @since 1.4.3
+		 */
+		private static $instance;
+
+		/**
+		 * Initiator
+		 *
+		 * @since 1.4.3
+		 * @return object initialized object of class.
+		 */
+		public static function get_instance() {
+			if ( ! isset( self::$instance ) ) {
+				self::$instance = new self;
+			}
+			return self::$instance;
+		}
+
+		/**
+		 * Constructor
+		 *
+		 * @since 1.4.3
+		 */
+		public function __construct() {
+
+			/**
+			 * Add Slashes
+			 *
+			 * @todo    Elementor already have below code which works on defining the constant `WP_LOAD_IMPORTERS`.
+			 *          After defining the constant `WP_LOAD_IMPORTERS` in WP CLI it was not works.
+			 *          Try to remove below duplicate code in future.
+			 */
+			if ( defined( 'WP_CLI' ) ) {
+				add_filter( 'wp_import_post_meta', array( $this, 'on_wp_import_post_meta' ) );
+				add_filter( 'wxr_importer.pre_process.post_meta', array( $this, 'on_wxr_importer_pre_process_post_meta' ) );
+			}
+		}
+
+		/**
+		 * Process post meta before WP importer.
+		 *
+		 * Normalize Elementor post meta on import, We need the `wp_slash` in order
+		 * to avoid the unslashing during the `add_post_meta`.
+		 *
+		 * Fired by `wp_import_post_meta` filter.
+		 *
+		 * @since 1.4.3
+		 * @access public
+		 *
+		 * @param array $post_meta Post meta.
+		 *
+		 * @return array Updated post meta.
+		 */
+		public function on_wp_import_post_meta( $post_meta ) {
+			foreach ( $post_meta as &$meta ) {
+				if ( '_elementor_data' === $meta['key'] ) {
+					$meta['value'] = wp_slash( $meta['value'] );
+					break;
+				}
+			}
+
+			return $post_meta;
+		}
+
+		/**
+		 * Process post meta before WXR importer.
+		 *
+		 * Normalize Elementor post meta on import with the new WP_importer, We need
+		 * the `wp_slash` in order to avoid the unslashing during the `add_post_meta`.
+		 *
+		 * Fired by `wxr_importer.pre_process.post_meta` filter.
+		 *
+		 * @since 1.4.3
+		 * @access public
+		 *
+		 * @param array $post_meta Post meta.
+		 *
+		 * @return array Updated post meta.
+		 */
+		public function on_wxr_importer_pre_process_post_meta( $post_meta ) {
+			if ( '_elementor_data' === $post_meta['key'] ) {
+				$post_meta['value'] = wp_slash( $post_meta['value'] );
+			}
+
+			return $post_meta;
+		}
+	}
+
+	/**
+	 * Kicking this off by calling 'get_instance()' method
+	 */
+	Astra_Sites_Compatibility_Elementor::get_instance();
+
+endif;

--- a/inc/classes/compatibility/sfwd-lms/class-astra-sites-compatibility-sfwd-lms.php
+++ b/inc/classes/compatibility/sfwd-lms/class-astra-sites-compatibility-sfwd-lms.php
@@ -49,13 +49,6 @@ if ( ! class_exists( 'Astra_Sites_Compatibility_SFWD_LMS' ) ) :
 		}
 
 		/**
-		 * Add post types
-		 *
-		 * @since 1.3.13
-		 * @return array Post types.
-		 */
-
-		/**
 		 * Set post types
 		 *
 		 * @since 1.3.13

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing.php
@@ -145,11 +145,7 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing' ) ) :
 			// @todo Remove required `allow_url_fopen` support.
 			if ( ini_get( 'allow_url_fopen' ) ) {
 				if ( is_plugin_active( 'elementor/elementor.php' ) ) {
-					if ( defined( 'WP_CLI' ) ) {
-						$import = new Elementor\TemplateLibrary\Astra_Sites_Batch_Processing_Elementor();
-					} else {
-						$import = new \Elementor\TemplateLibrary\Astra_Sites_Batch_Processing_Elementor();
-					}
+					$import = new \Elementor\TemplateLibrary\Astra_Sites_Batch_Processing_Elementor();
 					self::$process_all->push_to_queue( $import );
 				}
 			} else {

--- a/inc/importers/batch-processing/helpers/class-astra-sites-image-importer.php
+++ b/inc/importers/batch-processing/helpers/class-astra-sites-image-importer.php
@@ -142,7 +142,7 @@ if ( ! class_exists( 'Astra_Sites_Image_Importer' ) ) :
 						"SELECT post_id FROM {$wpdb->postmeta}
 						WHERE meta_key = '_wp_attached_file'
 						AND meta_value LIKE %s",
-						'%' . $filename . '%'
+						'%/' . $filename . '%'
 					)
 				);
 

--- a/languages/astra-sites.pot
+++ b/languages/astra-sites.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Astra Starter Sites package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Astra Starter Sites 1.4.2\n"
+"Project-Id-Version: Astra Starter Sites 1.4.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/astra-sites\n"
-"POT-Creation-Date: 2019-11-04 09:57:18+00:00\n"
+"POT-Creation-Date: 2019-11-07 08:15:54+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -53,12 +53,12 @@ msgstr ""
 #: inc/classes/class-astra-sites-importer.php:426
 #: inc/classes/class-astra-sites-importer.php:472
 #: inc/classes/class-astra-sites-importer.php:519
-#: inc/classes/class-astra-sites-importer.php:654
-#: inc/classes/class-astra-sites-importer.php:682
-#: inc/classes/class-astra-sites-importer.php:716
-#: inc/classes/class-astra-sites-importer.php:768
-#: inc/classes/class-astra-sites-importer.php:807
-#: inc/classes/class-astra-sites-importer.php:842
+#: inc/classes/class-astra-sites-importer.php:649
+#: inc/classes/class-astra-sites-importer.php:677
+#: inc/classes/class-astra-sites-importer.php:711
+#: inc/classes/class-astra-sites-importer.php:763
+#: inc/classes/class-astra-sites-importer.php:802
+#: inc/classes/class-astra-sites-importer.php:837
 #: inc/classes/class-astra-sites.php:85 inc/classes/class-astra-sites.php:104
 msgid "You are not allowed to perform this action"
 msgstr ""
@@ -182,7 +182,7 @@ msgid "Are you sure you want to import the site?"
 msgstr ""
 
 #: inc/classes/class-astra-sites-wp-cli.php:140
-#: inc/classes/class-astra-sites-wp-cli.php:345
+#: inc/classes/class-astra-sites-wp-cli.php:375
 msgid "Invalid Site ID,"
 msgstr ""
 
@@ -216,81 +216,97 @@ msgstr ""
 msgid "Activating Plugins.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:238
-#. translators: %s is the XML file URL.
-msgid "Downloading %s"
-msgstr ""
-
 #: inc/classes/class-astra-sites-wp-cli.php:242
-msgid "Importing WXR.."
-msgstr ""
-
-#: inc/classes/class-astra-sites-wp-cli.php:246
-#. translators: %s is error message.
-msgid "WXR file Download Failed. Error %s"
-msgstr ""
-
-#: inc/classes/class-astra-sites-wp-cli.php:254
 #: inc/classes/class-astra-sites.php:443
 msgid "Importing Site Options.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:262
+#: inc/classes/class-astra-sites-wp-cli.php:250
 #: inc/classes/class-astra-sites.php:444
 msgid "Importing Widgets.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:272
+#: inc/classes/class-astra-sites-wp-cli.php:260
 #. translators: %s is the site URL.
 msgid ""
 "Site Imported Successfully!\n"
 "Visit: %s"
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:291
+#: inc/classes/class-astra-sites-wp-cli.php:288
+msgid "Invalid XML URL."
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:293
+#. translators: %s is the XML file URL.
+msgid "Downloading %s"
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:297
+msgid "Importing WXR.."
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:301
+#. translators: %s is error message.
+msgid "WXR file Download Failed. Error %s"
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:321
 msgid "Are you sure you want to delete imported site data?"
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:299
+#: inc/classes/class-astra-sites-wp-cli.php:329
 msgid "Reseting Posts.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:306
+#: inc/classes/class-astra-sites-wp-cli.php:336
 msgid "Reseting Terms.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:313
+#: inc/classes/class-astra-sites-wp-cli.php:343
 msgid "Resting WP Forms..."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:350
+#: inc/classes/class-astra-sites-wp-cli.php:380
 msgid "Importing customizer settings.."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:386
+#: inc/classes/class-astra-sites-wp-cli.php:416
 msgid "Please add valid parameter."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:403
+#: inc/classes/class-astra-sites-wp-cli.php:433
 #. translators: %s is the current page builder name.
 msgid "Default page builder is \"%s\"."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:411
+#: inc/classes/class-astra-sites-wp-cli.php:441
 #. translators: %s is the page builder name.
 msgid "\"%s\" is set as default page builder."
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:414
+#: inc/classes/class-astra-sites-wp-cli.php:444
 msgid ""
 "Invalid page builder slug. \n"
 "Check all page builder slugs with command `wp astra-sites page_builder list`"
 msgstr ""
 
-#: inc/classes/class-astra-sites-wp-cli.php:417
+#: inc/classes/class-astra-sites-wp-cli.php:447
 msgid ""
 "Invalid parameter! \n"
 "Please use `list` or `set` parameter."
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:499
+msgid "This site page builder is not exist. Try different site page builder."
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:508
+msgid "This site type is not exist. Try different site type."
+msgstr ""
+
+#: inc/classes/class-astra-sites-wp-cli.php:517
+msgid "This site category is not exist. Try different site category."
 msgstr ""
 
 #: inc/classes/class-astra-sites.php:112

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-sites",
-  "version": "1.3.22",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astra-sites",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Elementor,Beaver Builder,Templates,Gutenberg,Astra Starter Sites
 Requires at least: 4.4
 Requires PHP: 5.3
 Tested up to: 5.2
-Stable tag: 1.4.2
+Stable tag: 1.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -116,6 +116,12 @@ We are open to suggestions and would love to work on topics that our users are l
 3. Click the import site button to start the import process.
 
 == Changelog ==
+
+v1.4.3 - 7-November-2019
+- Fix: Installing premium plugin from the WP CLI import.
+- Fix: WP CLI command `wp astra-sites list` showing the old result.
+- Fix: PHP error Astra_Sites_Batch_Processing_Elementor does not exist from WP CLI import.
+- Improvement: Some Elementor templates broken due to the missing wp_slash() from WP CLI import.
 
 v1.4.2 - 4-November-2019
 - Fix: Correctly added nonce to allow notice to be dismissed.


### PR DESCRIPTION
- Fix: Installing premium plugin from the WP CLI import.
- Fix: WP CLI command `wp astra-sites list` showing the old result.
- Fix: PHP error Astra_Sites_Batch_Processing_Elementor does not exist from WP CLI import.
- Improvement: Some Elementor templates broken due to the missing wp_slash() from WP CLI import.