### PR TITLE
Added the ast- prefix for all icon fonts.

### DIFF
--- a/inc/assets/css/admin-rtl.css
+++ b/inc/assets/css/admin-rtl.css
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+[class^="ast-icon-"], [class*=" ast-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'icomoon' !important;
   speak: none;
@@ -24,22 +24,22 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-search:before {
+.ast-icon-search:before {
   content: "\e900";
 }
-.icon-heart:before {
+.ast-icon-heart:before {
   content: "\e901";
 }
-.icon-refresh:before {
+.ast-icon-refresh:before {
   content: "\e902";
 }
-.icon-chevron-left:before {
+.ast-icon-chevron-left:before {
   content: "\e904";
 }
-.icon-file:before {
+.ast-icon-file:before {
   content: "\e903";
 }
-.icon-layers:before {
+.ast-icon-layers:before {
   content: "\e905";
 }
 
@@ -397,7 +397,7 @@
     transition-duration: .05s;
     transition-timing-function: ease-in-out;
 }
-.theme-id-container .icon-star {
+.theme-id-container .ast-icon-star {
     padding: 0 0 0 15px;
 }
 .wrap .status {
@@ -1093,14 +1093,14 @@ body.loading-content .select-page-builder {
 .astra-sites-show-favorite-button.active {
     color: transparent;
 }
-.filter-links li > .astra-sites-show-favorite-button.current:hover .icon-heart,
-.filter-links li > .astra-sites-show-favorite-button.current .icon-heart,
-.filter-links li > .astra-sites-show-favorite-button:hover .icon-heart,
-.astra-sites-show-favorite-button.active .icon-heart {
+.filter-links li > .astra-sites-show-favorite-button.current:hover .ast-icon-heart,
+.filter-links li > .astra-sites-show-favorite-button.current .ast-icon-heart,
+.filter-links li > .astra-sites-show-favorite-button:hover .ast-icon-heart,
+.astra-sites-show-favorite-button.active .ast-icon-heart {
     color: #c34444;
 }
 
-.icon-heart {
+.ast-icon-heart {
     color: #666;
 }
 .header-actions a:focus {

--- a/inc/assets/css/admin.css
+++ b/inc/assets/css/admin.css
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+[class^="ast-icon-"], [class*=" ast-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'icomoon' !important;
   speak: none;
@@ -24,22 +24,22 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-search:before {
+.ast-icon-search:before {
   content: "\e900";
 }
-.icon-heart:before {
+.ast-icon-heart:before {
   content: "\e901";
 }
-.icon-refresh:before {
+.ast-icon-refresh:before {
   content: "\e902";
 }
-.icon-chevron-left:before {
+.ast-icon-chevron-left:before {
   content: "\e904";
 }
-.icon-file:before {
+.ast-icon-file:before {
   content: "\e903";
 }
-.icon-layers:before {
+.ast-icon-layers:before {
   content: "\e905";
 }
 
@@ -397,7 +397,7 @@
     transition-duration: .05s;
     transition-timing-function: ease-in-out;
 }
-.theme-id-container .icon-star {
+.theme-id-container .ast-icon-star {
     padding: 0 15px 0 0;
 }
 .wrap .status {
@@ -1093,14 +1093,14 @@ body.loading-content .select-page-builder {
 .astra-sites-show-favorite-button.active {
     color: transparent;
 }
-.filter-links li > .astra-sites-show-favorite-button.current:hover .icon-heart,
-.filter-links li > .astra-sites-show-favorite-button.current .icon-heart,
-.filter-links li > .astra-sites-show-favorite-button:hover .icon-heart,
-.astra-sites-show-favorite-button.active .icon-heart {
+.filter-links li > .astra-sites-show-favorite-button.current:hover .ast-icon-heart,
+.filter-links li > .astra-sites-show-favorite-button.current .ast-icon-heart,
+.filter-links li > .astra-sites-show-favorite-button:hover .ast-icon-heart,
+.astra-sites-show-favorite-button.active .ast-icon-heart {
     color: #c34444;
 }
 
-.icon-heart {
+.ast-icon-heart {
     color: #666;
 }
 .header-actions a:focus {

--- a/inc/assets/css/elementor-admin-rtl.css
+++ b/inc/assets/css/elementor-admin-rtl.css
@@ -892,7 +892,7 @@
     border-radius: 6px;
     position: relative;
 }
-#ast-sites-modal .icon-search {
+#ast-sites-modal .ast-icon-search {
     position: absolute;
     left: 0;
     top: 0;

--- a/inc/assets/css/elementor-admin.css
+++ b/inc/assets/css/elementor-admin.css
@@ -892,7 +892,7 @@
     border-radius: 6px;
     position: relative;
 }
-#ast-sites-modal .icon-search {
+#ast-sites-modal .ast-icon-search {
     position: absolute;
     right: 0;
     top: 0;

--- a/inc/assets/css/images-rtl.css
+++ b/inc/assets/css/images-rtl.css
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+[class^="ast-icon-"], [class*=" ast-icon-"] {
     font-family: 'icomoon' !important;
     speak: none;
     font-style: normal;
@@ -21,11 +21,11 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-chevron-left:before {
+.ast-icon-chevron-left:before {
   content: "\e904";
 }
 
-.icon-search:before {
+.ast-icon-search:before {
   content: "\e900";
 }
 

--- a/inc/assets/css/images.css
+++ b/inc/assets/css/images.css
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+[class^="ast-icon-"], [class*=" ast-icon-"] {
     font-family: 'icomoon' !important;
     speak: none;
     font-style: normal;
@@ -21,11 +21,11 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-chevron-left:before {
+.ast-icon-chevron-left:before {
   content: "\e904";
 }
 
-.icon-search:before {
+.ast-icon-search:before {
   content: "\e900";
 }
 

--- a/inc/assets/js/dist/index.js
+++ b/inc/assets/js/dist/index.js
@@ -193,7 +193,7 @@ AstraAttachmentsBrowser = Frame.extend({
         // this.views.add( this.attachmentsHeading );
         this.views.add(new wp.media.view.AstraContent());
         this.$el.find('.ast-image__search').wrapAll('<div class="ast-image__search-wrap">').parent().html();
-        this.$el.find('.ast-image__search-wrap').append('<span class="icon-search search-icon"></span>');
+        this.$el.find('.ast-image__search-wrap').append('<span class="ast-icon-search search-icon"></span>');
     },
 
     photoUploadComplete: function photoUploadComplete(savedImage) {

--- a/inc/assets/js/src/frame.js
+++ b/inc/assets/js/src/frame.js
@@ -32,7 +32,7 @@ AstraAttachmentsBrowser = Frame.extend({
         // this.views.add( this.attachmentsHeading );
         this.views.add( new wp.media.view.AstraContent );
         this.$el.find( '.ast-image__search' ).wrapAll( '<div class="ast-image__search-wrap">' ).parent().html();
-        this.$el.find( '.ast-image__search-wrap' ).append( '<span class="icon-search search-icon"></span>' );
+        this.$el.find( '.ast-image__search-wrap' ).append( '<span class="ast-icon-search search-icon"></span>' );
     },
 
     photoUploadComplete: function( savedImage ) {

--- a/inc/classes/class-astra-sites-page.php
+++ b/inc/classes/class-astra-sites-page.php
@@ -489,7 +489,7 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 						</div>
 					</div>
 
-					<div class="back-to-layout" title="Back to Layout"><i class="icon-chevron-left"></i></div>
+					<div class="back-to-layout" title="Back to Layout"><i class="ast-icon-chevron-left"></i></div>
 					<div id="astra-sites-filters" class="hide-on-mobile">
 						<?php $this->site_filters(); ?>
 					</div>
@@ -499,12 +499,12 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 								<ul class="filter-links">
 									<li>
 										<a title="<?php esc_html_e( 'My Favorite', 'astra-sites' ); ?>" href="#" class="astra-sites-show-favorite-button">
-											<i class="icon-heart"></i>
+											<i class="ast-icon-heart"></i>
 										</a>
 									</li>
 									<li>
 										<a title="<?php esc_html_e( 'Sync Library', 'astra-sites' ); ?>" href="#" class="astra-sites-sync-library-button">
-											<i class="icon-refresh"></i>
+											<i class="ast-icon-refresh"></i>
 										</a>
 									</li>
 								</ul>
@@ -625,7 +625,7 @@ if ( ! class_exists( 'Astra_Sites_Page' ) ) {
 						}
 						?>
 						<input autocomplete="off" placeholder="<?php esc_html_e( 'Search...', 'astra-sites' ); ?>" type="search" aria-describedby="live-search-desc" id="wp-filter-search-input" class="wp-filter-search">
-						<span class="icon-search search-icon"></span>
+						<span class="ast-icon-search search-icon"></span>
 						<div class="astra-sites-autocomplete-result"></div>
 					</div>
 				</div>

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -101,7 +101,8 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 
 			$this->includes();
 
-			add_action( 'plugin_action_links_' . ASTRA_SITES_BASE, array( $this, 'action_links' ) );
+			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+			add_action( 'astra_notice_before_markup', array( $this, 'notice_assets' ) );
 			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue' ), 99 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'image_search_scripts' ) );
@@ -901,7 +902,73 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		public function load_textdomain() {
 			load_plugin_textdomain( 'astra-sites' );
 		}
-		
+
+		/**
+		 * Enqueue Astra Notices CSS.
+		 *
+		 * @since 2.3.6
+		 *
+		 * @return void
+		 */
+		public static function notice_assets() {
+			$file = is_rtl() ? 'astra-notices-rtl.css' : 'astra-notices.css';
+			wp_enqueue_style( 'astra-sites-notices', ASTRA_SITES_URI . 'inc/assets/css/' . $file, array(), ASTRA_SITES_VER );
+		}
+
+		/**
+		 * Admin Notices
+		 *
+		 * @since 1.0.5
+		 * @return void
+		 */
+		public function admin_notices() {
+
+			$image_path = esc_url( ASTRA_SITES_URI . 'inc/assets/images/logo.svg' );
+
+			Astra_Notices::add_notice(
+				array(
+					'id'      => 'astra-sites-5-start-notice',
+					'type'    => 'info',
+					'class'   => 'astra-sites-5-star',
+					'show_if' => ( false === Astra_Sites_White_Label::get_instance()->is_white_labeled() ),
+					/* translators: %1$s white label plugin name and %2$s deactivation link */
+					'message' => sprintf(
+						'<div class="notice-image" style="display: flex;">
+							<img src="%1$s" class="custom-logo" alt="Starter Templates" itemprop="logo" style="max-width: 90px;"></div>
+							<div class="notice-content">
+								<div class="notice-heading">
+									%2$s
+								</div>
+								%3$s<br />
+								<div class="astra-review-notice-container">
+									<a href="%4$s" class="astra-notice-close astra-review-notice button-primary" target="_blank">
+									%5$s
+									</a>
+								<span class="dashicons dashicons-calendar"></span>
+									<a href="#" data-repeat-notice-after="%6$s" class="astra-notice-close astra-review-notice">
+									%7$s
+									</a>
+								<span class="dashicons dashicons-smiley"></span>
+									<a href="#" class="astra-notice-close astra-review-notice">
+									%8$s
+									</a>
+								</div>
+							</div>',
+						$image_path,
+						__( 'Hello! Seems like you have used Starter Templates to build this website &mdash; Thanks a ton!', 'astra-sites' ),
+						__( 'Could you please do us a BIG favor and give it a 5-star rating on WordPress? This would boost our motivation and help other users make a comfortable decision while choosing the Starter Templates.', 'astra-sites' ),
+						'https://wordpress.org/support/plugin/astra-sites/reviews/?filter=5#new-post',
+						__( 'Ok, you deserve it', 'astra-sites' ),
+						MONTH_IN_SECONDS,
+						__( 'Nope, maybe later', 'astra-sites' ),
+						__( 'I already did', 'astra-sites' )
+					),
+				)
+			);
+
+			add_action( 'plugin_action_links_' . ASTRA_SITES_BASE, array( $this, 'action_links' ) );
+		}
+
 		/**
 		 * Show action links on the plugin screen.
 		 *

--- a/inc/includes/admin-page.php
+++ b/inc/includes/admin-page.php
@@ -222,7 +222,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<# if ( '' === type || 'site' === type ) { #>
 					<div class="favorite-action-wrap" data-favorite="{{favorite_class}}" title="{{favorite_title}}">
-						<i class="icon-heart"></i>
+						<i class="ast-icon-heart"></i>
 					</div>
 				<# } #>
 			</div>
@@ -311,7 +311,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</div>
 						<# if ( '' === type || 'site' === type ) { #>
 							<div class="favorite-action-wrap" data-favorite="{{favorite_class}}" title="{{favorite_title}}">
-								<i class="icon-heart"></i>
+								<i class="ast-icon-heart"></i>
 							</div>
 						<# } #>
 					</div>
@@ -372,7 +372,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</div>
 						<# if ( '' === type || 'site' === type ) { #>
 							<div class="favorite-action-wrap" data-favorite="{{favorite_class}}" title="{{favorite_title}}">
-								<i class="icon-heart"></i>
+								<i class="ast-icon-heart"></i>
 							</div>
 						<# } #>
 					</div>

--- a/inc/includes/image-templates.php
+++ b/inc/includes/image-templates.php
@@ -116,7 +116,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <script type="text/template" id="tmpl-ast-image-go-back">
 	<span class="ast-image__go-back">
-		<i class="icon-chevron-left"></i>
+		<i class="ast-icon-chevron-left"></i>
 		<span class="ast-image__go-back-text"><?php esc_html_e( 'Back to Images', 'astra-sites' ); ?></span>
 	</span>
 </script>

--- a/inc/includes/templates.php
+++ b/inc/includes/templates.php
@@ -109,12 +109,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 				}
 				?>
-				<div class="back-to-layout" title="<?php esc_html_e( 'Back to Layout', 'astra-sites' ); ?>" data-step="1"><i class="icon-chevron-left"></i></div>
+				<div class="back-to-layout" title="<?php esc_html_e( 'Back to Layout', 'astra-sites' ); ?>" data-step="1"><i class="ast-icon-chevron-left"></i></div>
 			</div>
 			<div class="elementor-templates-modal__header__menu-area astra-sites-step-1-wrap ast-sites-modal__options">
 				<div class="elementor-template-library-header-menu">
-					<div class="elementor-template-library-menu-item elementor-active" data-template-source="remote" data-template-type="pages"><span class="icon-file"></span><?php esc_html_e( 'Pages', 'astra-sites' ); ?></div>		
-					<div class="elementor-template-library-menu-item" data-template-source="remote" data-template-type="blocks"><span class="icon-layers"></span><?php esc_html_e( 'Blocks', 'astra-sites' ); ?></div>
+					<div class="elementor-template-library-menu-item elementor-active" data-template-source="remote" data-template-type="pages"><span class="ast-icon-file"></span><?php esc_html_e( 'Pages', 'astra-sites' ); ?></div>		
+					<div class="elementor-template-library-menu-item" data-template-source="remote" data-template-type="blocks"><span class="ast-icon-layers"></span><?php esc_html_e( 'Blocks', 'astra-sites' ); ?></div>
 				</div>
 			</div>
 			<div class="elementor-templates-modal__header__items-area">
@@ -124,7 +124,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="astra-sites__sync-wrap">
 					<div class="astra-sites-sync-library-button">
-						<span class="icon-refresh" aria-hidden="true" title="<?php esc_html_e( 'Sync Library', 'astra-sites' ); ?>"></span>
+						<span class="ast-icon-refresh" aria-hidden="true" title="<?php esc_html_e( 'Sync Library', 'astra-sites' ); ?>"></span>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### Description

Recently we have used CSS class `icon-*` which create conflict with other plugins and themes. Now, we have added the `ast-` prefix for all the icon font CSS classes. 

### How has this been tested?
Manually tested.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
