### PR TITLE
fix: template preview vanish during import

### DIFF
--- a/inc/assets/css/admin.css
+++ b/inc/assets/css/admin.css
@@ -1511,7 +1511,7 @@ body.loading-content .select-page-builder {
 	right: 0;
 	top: 0;
 	bottom: 0;
-	background: #fff;
+	background: transparent;
 	overflow-y: auto;
 }
 


### PR DESCRIPTION
When we click on Import button - Template doesn't appear in the background - https://a.cl.ly/X6ueOngn