### PR TITLE
ST-183 - fix: subscription form shows again once subscribed

### DIFF
--- a/inc/assets/js/admin-page.js
+++ b/inc/assets/js/admin-page.js
@@ -636,8 +636,11 @@ var AstraSitesAjaxQueue = (function () {
 					AstraSitesAdmin.page_import_complete();
 				}
 			}
-
-			astraSitesVars.subscribed = 'yes';
+			if(event && event.target.classList.value == 'button-subscription-skip') {
+				astraSitesVars.subscribed = '';
+			}else{
+				astraSitesVars.subscribed = 'yes';
+			}
 		},
 
 		_subscribe: function (event) {
@@ -3628,7 +3631,7 @@ var AstraSitesAjaxQueue = (function () {
 				return;
 			}
 
-			if ($('.subscription-enabled').length) {
+			if ($('.subscription-enabled').length && astraSitesVars.subscribed !== 'yes') {
 				$('.subscription-popup').show();
 				$('.astra-sites-result-preview .default').hide();
 			} else {


### PR DESCRIPTION
3. I can see the form on single page import - https://a.cl.ly/ApuYjPQO Does we do ?? I have subscribed on Import Complete Site but again I can see popup on single page import
---
Test Case -

1. Install Free Starter Templates on a fresh setup
2. Import Outdoor Adventure Template 
3. Submit the subscription form and complete the importing.
3. Once the import is completed click on a single page import without refreshing the page.
4. During single page import, it should not ask for the subscription form again.