### PR TITLE
fix:contact forms in gutenberg template

### DIFF
--- a/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing-gutenberg.php
@@ -146,6 +146,7 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing_Gutenberg' ) ) :
 				// Replace ID's.
 				foreach ( $ids_mapping as $old_id => $new_id ) {
 					$content = str_replace( '[wpforms id="' . $old_id, '[wpforms id="' . $new_id, $content );
+					$content = str_replace( '{"formId":"' . $old_id . '"}', '{"formId":"' . $new_id . '"}', $content );
 				}
 			}
 


### PR DESCRIPTION
Test Case -

1. Import the Outdoor Adventure template and check the contact page in the frontend.
2. Previously it was not showing the form and now this PR fixes the same.