### PR TITLE
fix: hide delete previous site option on single page import

### DIFF
--- a/inc/assets/js/admin-page.js
+++ b/inc/assets/js/admin-page.js
@@ -3582,7 +3582,7 @@ var AstraSitesAjaxQueue = (function () {
 							$('.astra-sites-result-preview').find('.astra-sites-import-plugins').show();
 							$('.astra-sites-result-preview').find('.required-plugins-list').html(output);
 						}
-						if ('yes' === AstraSitesAdmin.first_import_complete) {
+						if ('yes' === AstraSitesAdmin.first_import_complete && !$('.astra-sites-result-preview').hasClass('import-page')) {
 							$('.astra-sites-advanced-options').find('.astra-site-contents').prepend(wp.template('astra-sites-delete-previous-site'));
 						}
 


### PR DESCRIPTION
Test Case - 

1. Import outdoor adventure template and then without refresh import single page.
2. Delete previous site option should no show for a single page import