### PR TITLE
Feat: Added source parameter with subscribe form submission action

### DIFF
--- a/inc/assets/js/admin-page.js
+++ b/inc/assets/js/admin-page.js
@@ -701,6 +701,7 @@ var AstraSitesAjaxQueue = (function () {
 				PAGE_BUILDER: astraSitesVars.default_page_builder_data.name,
 				WP_USER_TYPE: subscription_user_type,
 				BUILD_WEBSITE_FOR: subscription_build_for,
+				SOURCE: hfe_admin_data.data_source
 			};
 
 			$.ajax({

--- a/inc/assets/js/admin-page.js
+++ b/inc/assets/js/admin-page.js
@@ -701,7 +701,7 @@ var AstraSitesAjaxQueue = (function () {
 				PAGE_BUILDER: astraSitesVars.default_page_builder_data.name,
 				WP_USER_TYPE: subscription_user_type,
 				BUILD_WEBSITE_FOR: subscription_build_for,
-				SOURCE: hfe_admin_data.data_source
+				SOURCE: astraSitesVars.data_source
 			};
 
 			$.ajax({

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -1326,6 +1326,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 						'themeInstall' => sprintf( __( 'Installing %1$s Theme..', 'astra-sites' ), Astra_Sites_White_Label::get_instance()->get_option( 'astra', 'name', 'Astra' ) ),
 					),
 					'default_page_builder'               => $default_page_builder,
+					'data_source'						=> 'astra-sites',
 					'default_page_builder_data'          => Astra_Sites_Page::get_instance()->get_default_page_builder(),
 					'default_page_builder_sites'         => Astra_Sites_Page::get_instance()->get_sites_by_page_builder( $default_page_builder ),
 					'sites'                              => $request_params,

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -1070,7 +1070,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 * @since  1.0.0
 		 */
 		public static function get_api_domain() {
-			return 'https://mitras11.sg-host.com/';
+			return defined( 'STARTER_TEMPLATES_REMOTE_URL' ) ? STARTER_TEMPLATES_REMOTE_URL : apply_filters( 'astra_sites_api_domain', 'https://websitedemos.net/' );
 		}
 
 		/**

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -1070,7 +1070,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 		 * @since  1.0.0
 		 */
 		public static function get_api_domain() {
-			return defined( 'STARTER_TEMPLATES_REMOTE_URL' ) ? STARTER_TEMPLATES_REMOTE_URL : apply_filters( 'astra_sites_api_domain', 'https://websitedemos.net/' );
+			return 'https://mitras11.sg-host.com/';
 		}
 
 		/**
@@ -1326,7 +1326,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 						'themeInstall' => sprintf( __( 'Installing %1$s Theme..', 'astra-sites' ), Astra_Sites_White_Label::get_instance()->get_option( 'astra', 'name', 'Astra' ) ),
 					),
 					'default_page_builder'               => $default_page_builder,
-					'data_source'						=> 'astra-sites',
+					'data_source'                        => 'astra-sites',
 					'default_page_builder_data'          => Astra_Sites_Page::get_instance()->get_default_page_builder(),
 					'default_page_builder_sites'         => Astra_Sites_Page::get_instance()->get_sites_by_page_builder( $default_page_builder ),
 					'sites'                              => $request_params,

--- a/readme.txt
+++ b/readme.txt
@@ -149,6 +149,9 @@ We are open to suggestions and would love to work on topics that our users are l
 
 == Changelog ==
 
+v2.6.11.1 - Development Version
+- Improvement: Added a source parameter with subscription form submission request.
+
 v2.6.11 - 3-June-2021
 - Improvement: Gutenberg Template library auto-syncs at regular intervals.
 - Improvement: Updated image download functionality.


### PR DESCRIPTION
### Description
Added `Source` parameter for SendInBlue form submission. 
For this, I have made few changes to the Email Subscribe-related code in our Astra sites server plugin. 
Here is a reference PR - https://github.com/brainstormforce/astra-sites-server/pull/7

### Screenshots
N/A

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
- Install Starter Templates plugin.
- Go to Settings -> Import any Template
- Submit the form that appears in the popup.
- - Check if it works properly

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
