### PR TITLE
use actions from 10up instead of using the forked actions

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml.yml
+++ b/.github/workflows/push-asset-readme-update.yml.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@master
+      uses: 10up/action-wordpress-plugin-asset-update@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+
     - name: WordPress Plugin Deploy
-      uses: Nikschavan/action-wordpress-plugin-deploy@develop
+      uses: 10up/action-wordpress-plugin-deploy@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Use upstream repo instead of using forked GitHub actions.

We were using forked actions in #136 for one bug fix that was not included in upstream.