### PR TITLE
Updated Gutenberg Templates v1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Starter Templates — Elementor, Gutenberg & Beaver Builder Templates #
-**Contributors:** [brainstormforce](https://profiles.wordpress.org/brainstormforce)  
-**Donate link:** https://wpastra.com/pro/  
-**Tags:** Elementor,Beaver Builder,Templates,Gutenberg,Astra Starter Sites  
-**Requires at least:** 4.4  
-**Requires PHP:** 5.3  
-**Tested up to:** 5.8  
-**Stable tag:** 2.6.17  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Contributors:** [brainstormforce](https://profiles.wordpress.org/brainstormforce)
+**Donate link:** https://wpastra.com/pro/
+**Tags:** Elementor,Beaver Builder,Templates,Gutenberg,Astra Starter Sites
+**Requires at least:** 4.4
+**Requires PHP:** 5.3
+**Tested up to:** 5.8
+**Stable tag:** 2.6.17
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 The growing library of 300+ ready-to-use templates that work with all WordPress themes including Astra, Hello, OceanWP, GeneratePress and more
 
@@ -150,6 +150,7 @@ We are open to suggestions and would love to work on topics that our users are l
 ## Changelog ##
 
 v2.6.17 - 22-July-2021
+- Improvement: Avoided loading the Gutenberg Blocks scripts in the customizer screen.
 - Fix: Fixed the missing 'Create Gallery' button in Media Popup for Elementor editor.
 
 v2.6.16 - 19-July-2021

--- a/inc/lib/ast-block-templates/ast-block-templates.php
+++ b/inc/lib/ast-block-templates/ast-block-templates.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg Starter Templates
  * Plugin URI: https://wpastra.com/
  * Description: Gutenberg single page templates, and blocks library to imported your website easily.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Text Domain: ast-block-templates
@@ -21,7 +21,7 @@ if ( apply_filters( 'ast_block_templates_disable', false ) ) {
 
 // Set constants.
 define( 'AST_BLOCK_TEMPLATES_LIBRARY_URL', 'https://websitedemos.net/' );
-define( 'AST_BLOCK_TEMPLATES_VER', '1.0.7' );
+define( 'AST_BLOCK_TEMPLATES_VER', '1.0.8' );
 define( 'AST_BLOCK_TEMPLATES_FILE', __FILE__ );
 define( 'AST_BLOCK_TEMPLATES_BASE', plugin_basename( AST_BLOCK_TEMPLATES_FILE ) );
 define( 'AST_BLOCK_TEMPLATES_DIR', plugin_dir_path( AST_BLOCK_TEMPLATES_FILE ) );

--- a/inc/lib/ast-block-templates/classes/class-ast-block-templates.php
+++ b/inc/lib/ast-block-templates/classes/class-ast-block-templates.php
@@ -364,6 +364,11 @@ if ( ! class_exists( 'Ast_Block_Templates' ) ) :
 		 * @since 1.0.0
 		 */
 		public function template_assets() {
+
+			if ( ! is_admin() ) {
+				return;
+			}
+
 			wp_enqueue_script( 'ast-block-templates', AST_BLOCK_TEMPLATES_URI . 'dist/main.js', array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'masonry', 'imagesloaded', 'updates' ), AST_BLOCK_TEMPLATES_VER, true );
 			wp_add_inline_script( 'ast-block-templates', 'window.lodash = _.noConflict();', 'after' );
 
@@ -385,7 +390,7 @@ if ( ! class_exists( 'Ast_Block_Templates' ) ) :
 						'wpforms_status'          => $this->get_plugin_status( 'wpforms-lite/wpforms.php' ),
 						'gutenberg_status'        => $this->get_plugin_status( 'gutenberg/gutenberg.php' ),
 						'_ajax_nonce'             => wp_create_nonce( 'ast-block-templates-ajax-nonce' ),
-						'button_text'             => esc_html__( 'Starter Templates', 'astra-sites' ),
+						'button_text'             => esc_html__( 'Starter Templates', 'ast-block-templates' ),
 						'display_button_logo'     => true,
 						'popup_logo_uri'          => AST_BLOCK_TEMPLATES_URI . 'dist/logo.svg',
 						'button_logo'             => AST_BLOCK_TEMPLATES_URI . 'dist/starter-template-logo.svg',

--- a/inc/lib/ast-block-templates/version.json
+++ b/inc/lib/ast-block-templates/version.json
@@ -1,3 +1,3 @@
 {
-  "ast-block-templates": "1.0.7"
+  "ast-block-templates": "1.0.8"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,7 @@ We are open to suggestions and would love to work on topics that our users are l
 == Changelog ==
 
 v2.6.17 - 22-July-2021
+- Improvement: Avoided loading the Gutenberg Blocks scripts in the customizer screen.
 - Fix: Fixed the missing 'Create Gallery' button in Media Popup for Elementor editor.
 
 v2.6.16 - 19-July-2021


### PR DESCRIPTION
### Description
Updated the Gutenberg Templates v1.0.8 with below changes:

```
v1.0.8 - 22-June-2021
- Improvement: Avoided loading the Gutenberg Blocks scripts in the customizer screen.
```

### Checklist:
- [x] My code is tested
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->