### PR TITLE
ST-286- fix: contact form not visible if widgets are used in elementors

### DIFF
--- a/inc/importers/batch-processing/class-astra-sites-batch-processing-elementor.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing-elementor.php
@@ -108,6 +108,7 @@ class Astra_Sites_Batch_Processing_Elementor extends Source_Local {
 					foreach ( $ids_mapping as $old_id => $new_id ) {
 						$data = str_replace( '[wpforms id=\"' . $old_id, '[wpforms id=\"' . $new_id, $data );
 						$data = str_replace( '"select_form":"' . $old_id, '"select_form":"' . $new_id, $data );
+						$data = str_replace( '"form_id":"' . $old_id, '"form_id":"' . $new_id, $data );
 					}
 				}
 


### PR DESCRIPTION
### Description
Contact form not visible if widgets are used in elementor

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Import `Tech Blogger` and check for a contact form on the Contact page.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
