### PR TITLE
Manage sequence for initial ST load while install/active from Astra notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,11 @@
     "scripts": {
         "format": "phpcbf",
         "lint": "phpcs"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
+        }
     }
 }

--- a/inc/importers/batch-processing/class-astra-sites-batch-processing.php
+++ b/inc/importers/batch-processing/class-astra-sites-batch-processing.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Astra_Sites_Batch_Processing' ) ) :
 			add_filter( 'astra_sites_image_importer_skip_image', array( $this, 'skip_image' ), 10, 2 );
 			add_action( 'astra_sites_import_complete', array( $this, 'start_process' ) );
 			add_action( 'astra_sites_process_single', array( $this, 'start_process_single' ) );
-			add_action( 'admin_head', array( $this, 'start_importer' ) );
+			add_action( 'admin_init', array( $this, 'start_importer' ) );
 			add_action( 'wp_ajax_astra-sites-update-library', array( $this, 'update_library' ) );
 			add_action( 'wp_ajax_astra-sites-update-library-complete', array( $this, 'update_library_complete' ) );
 			add_action( 'wp_ajax_astra-sites-import-all-categories-and-tags', array( $this, 'import_all_categories_and_tags' ) );

--- a/inc/lib/onboarding/class-onboarding-loader.php
+++ b/inc/lib/onboarding/class-onboarding-loader.php
@@ -118,7 +118,8 @@ class Intelligent_Starter_Templates_Loader {
 	 */
 	public function enqueue_scripts( $hook = '' ) {
 
-		if( isset( $_GET['ast-disable-activation-notice'] ) ){ // After activating the starter template from Astra noticed for the first time, the templates was not displayed because of template import process not fully done.
+		// After activating the starter template from Astra notice for the first time, the templates was not displayed because of template import process not fully done.
+		if( isset( $_GET['ast-disable-activation-notice'] ) ){
 			$current_url = home_url( $_SERVER['REQUEST_URI'] );
 			$current_url = str_replace( '&ast-disable-activation-notice', '', $current_url );
 			wp_safe_redirect( $current_url );

--- a/inc/lib/onboarding/class-onboarding-loader.php
+++ b/inc/lib/onboarding/class-onboarding-loader.php
@@ -58,7 +58,7 @@ class Intelligent_Starter_Templates_Loader {
 		add_action( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
 		// Assets loading.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 999, 1 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 		add_filter( 'admin_init' , array( $this, 'st_brizy_flag_field' )  );
 	}
@@ -117,6 +117,14 @@ class Intelligent_Starter_Templates_Loader {
 	 * @return void
 	 */
 	public function enqueue_scripts( $hook = '' ) {
+
+		if( isset( $_GET['ast-disable-activation-notice'] ) ){
+			$current_url = home_url( $_SERVER['REQUEST_URI'] );
+			$current_url = str_replace( '&ast-disable-activation-notice', '', $current_url );
+			wp_safe_redirect( $current_url );
+			exit;
+		}
+
 		if ( 'appearance_page_starter-templates' !== $hook ) {
 			return;
 		}

--- a/inc/lib/onboarding/class-onboarding-loader.php
+++ b/inc/lib/onboarding/class-onboarding-loader.php
@@ -58,7 +58,7 @@ class Intelligent_Starter_Templates_Loader {
 		add_action( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
 		// Assets loading.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
 
 		add_filter( 'admin_init' , array( $this, 'st_brizy_flag_field' )  );
 	}

--- a/inc/lib/onboarding/class-onboarding-loader.php
+++ b/inc/lib/onboarding/class-onboarding-loader.php
@@ -58,7 +58,7 @@ class Intelligent_Starter_Templates_Loader {
 		add_action( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
 		// Assets loading.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 99 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 999, 1 );
 
 		add_filter( 'admin_init' , array( $this, 'st_brizy_flag_field' )  );
 	}

--- a/inc/lib/onboarding/class-onboarding-loader.php
+++ b/inc/lib/onboarding/class-onboarding-loader.php
@@ -118,7 +118,7 @@ class Intelligent_Starter_Templates_Loader {
 	 */
 	public function enqueue_scripts( $hook = '' ) {
 
-		if( isset( $_GET['ast-disable-activation-notice'] ) ){
+		if( isset( $_GET['ast-disable-activation-notice'] ) ){ // After activating the starter template from Astra noticed for the first time, the templates was not displayed because of template import process not fully done.
 			$current_url = home_url( $_SERVER['REQUEST_URI'] );
 			$current_url = str_replace( '&ast-disable-activation-notice', '', $current_url );
 			wp_safe_redirect( $current_url );


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
**Issue**
The starter template gives no template suggestion after selecting the page builder.

**When you install the Astra theme and Starter template for the first time, after the starter template is activated, it redirects you to the Site creation wizard. After that, you click on build your site > Select a page builder, and after on the page where it should list the templates, there are no suggestions of any templates at all.** 
https://monosnap.com/file/1ZdGDQ9N3Z62s8xagxZdfvgqdpwb0X

Task:  https://brainstormforce.atlassian.net/browse/STAR-44

**Fixed:**
After activating the starter template from Astra noticed for the first time.
https://d.pr/v/14fpJ4

### Screenshots
<!-- if applicable -->
https://d.pr/v/14fpJ4

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
