### PR TITLE
When whitelabel option is enabled it disabled  promotes Essential & Growth bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,11 @@
     "scripts": {
         "format": "phpcbf",
         "lint": "phpcs"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
+        }
     }
 }

--- a/inc/classes/class-astra-sites.php
+++ b/inc/classes/class-astra-sites.php
@@ -1693,7 +1693,7 @@ if ( ! class_exists( 'Astra_Sites' ) ) :
 					'isPro'                              => defined( 'ASTRA_PRO_SITES_NAME' ) ? true : false,
 					'isWhiteLabeled'                     => Astra_Sites_White_Label::get_instance()->is_white_labeled(),
 					'whiteLabelName'                     => Astra_Sites_White_Label::get_instance()->get_white_label_name(),
-					'whiteLabelUrl'                      => Astra_Sites_White_Label::get_instance()->get_white_label_link( 'https://wpastra.com/docs/not-valid-license/' ),
+					'whiteLabelUrl'                      => Astra_Sites_White_Label::get_instance()->get_white_label_link( '#' ),
 					'ajaxurl'                            => esc_url( admin_url( 'admin-ajax.php' ) ),
 					'siteURL'                            => site_url(),
 					'getProText'                         => __( 'Get Access!', 'astra-sites' ),

--- a/inc/lib/onboarding/assets/src/steps/customize-site/customize-steps/license-validation/controls.js
+++ b/inc/lib/onboarding/assets/src/steps/customize-site/customize-steps/license-validation/controls.js
@@ -6,6 +6,7 @@ import Button from '../../../../components/button/button';
 import { useStateValue } from '../../../../store/store';
 import PreviousStepLink from '../../../../components/util/previous-step-link/index';
 import ICONS from '../../../../../icons';
+import { whiteLabelEnabled } from '../../../../utils/functions';
 import {
 	checkRequiredPlugins,
 	getDemo,
@@ -114,57 +115,60 @@ const LicenseValidationControls = () => {
 
 	return (
 		<>
-			<h4>{ __( 'Already a customer?', 'astra-sites' ) }</h4>
-
-			{ validateLicenseStatus && (
-				<p className="customer-notices">
-					{ __(
-						'If you have purchased our Essential or Growth Bundle, just enter your license key below to import this template.',
-						'astra-sites'
-					) }
-				</p>
-			) }
-
-			{ ! validateLicenseStatus && (
+			{ ! whiteLabelEnabled() && (
 				<>
-					<p
-						className="customer-notices"
-						dangerouslySetInnerHTML={ { __html: downloadLink } }
-					/>
+				<h4>{ __( 'Already a customer?', 'astra-sites' ) }</h4>
+
+				{ validateLicenseStatus && (
 					<p className="customer-notices">
 						{ __(
-							'Currently the free version is installed.',
+							'If you have purchased our Essential or Growth Bundle, just enter your license key below to import this template.',
 							'astra-sites'
 						) }
 					</p>
+				) }
+
+				{ ! validateLicenseStatus && (
+					<>
+						<p
+							className="customer-notices"
+							dangerouslySetInnerHTML={ { __html: downloadLink } }
+						/>
+						<p className="customer-notices">
+							{ __(
+								'Currently the free version is installed.',
+								'astra-sites'
+							) }
+						</p>
+					</>
+				) }
+				<p
+					className="support-link"
+					dangerouslySetInnerHTML={ { __html: supportLink } }
+				/>
+				{ validateLicenseStatus && (
+					<div className="license-wrap">
+						<input
+							type="text"
+							className="license-key-input"
+							name="license-key"
+							placeholder={ __( 'License key', 'astra-sites' ) }
+							required
+							onChange={ ( e ) => {
+								setLicenseKey( e.target.value );
+								setError( '' );
+							} }
+						/>
+						<Button
+							className={ `validate-btn ${ processingClass }` }
+							onClick={ validateKey }
+						>
+							{ ICONS.arrowRightBold }
+						</Button>
+					</div>
+				) }
 				</>
 			) }
-			<p
-				className="support-link"
-				dangerouslySetInnerHTML={ { __html: supportLink } }
-			/>
-			{ validateLicenseStatus && (
-				<div className="license-wrap">
-					<input
-						type="text"
-						className="license-key-input"
-						name="license-key"
-						placeholder={ __( 'License key', 'astra-sites' ) }
-						required
-						onChange={ ( e ) => {
-							setLicenseKey( e.target.value );
-							setError( '' );
-						} }
-					/>
-					<Button
-						className={ `validate-btn ${ processingClass }` }
-						onClick={ validateKey }
-					>
-						{ ICONS.arrowRightBold }
-					</Button>
-				</div>
-			) }
-
 			<PreviousStepLink onClick={ lastStep } customizeStep={ true }>
 				{ __( 'Back', 'astra-sites' ) }
 			</PreviousStepLink>

--- a/inc/lib/onboarding/assets/src/steps/customize-site/customize-steps/license-validation/index.js
+++ b/inc/lib/onboarding/assets/src/steps/customize-site/customize-steps/license-validation/index.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { useStateValue } from '../../../../store/store';
 import ChangeTemplate from '../../../../components/change-template';
 import Button from '../../../../components/button/button';
+import { whiteLabelEnabled } from '../../../../utils/functions';
 const { imageDir } = starterTemplates;
 
 const LicenseValidation = () => {
@@ -23,19 +24,29 @@ const LicenseValidation = () => {
 		window.open( astraSitesVars.cta_links[ builder ] );
 	};
 
+	const getwhiteLabelLink = () => {
+		if ( astraSitesVars.whiteLabelUrl !== '#' ) {
+			window.open( astraSitesVars.whiteLabelUrl );
+		}
+	};
+
 	return (
 		<>
 			<ChangeTemplate />
 			<div className="customizer-header">
 				<div className="header-name">
-					<h3 className="ist-customizer-heading">
-						{ __( 'Liked this Starter Template?', 'astra-sites' ) }
-					</h3>
-					<p
-						className="screen-description"
-						dangerouslySetInnerHTML={ { __html: accessLinkOutput } }
-					/>
-					<Button className="st-access-btn" onClick={ getAccessLink }>
+				{ ! whiteLabelEnabled() && (
+					<>
+						<h3 className="ist-customizer-heading">
+							{ __( 'Liked this Starter Template?', 'astra-sites' ) }
+						</h3>
+						<p
+							className="screen-description"
+							dangerouslySetInnerHTML={ { __html: accessLinkOutput } }
+						/>
+					</>
+				) }
+					<Button className="st-access-btn" onClick={ whiteLabelEnabled() ?  getwhiteLabelLink : getAccessLink }>
 						{ __( 'Unlock Access', 'astra-sites' ) }
 						<img
 							className="st-get-access"


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
1. When the white label is enabled and starter template details added we are disabled promotes Essential & Growth bundle.
2.  If the agency URL is present then we add that URL to the 'unlock access' button if empty then we add "#" on the link.
3. We only displayed unlock button on the page if while the label was enabled and starter template details were added.

Task link: https://brainstormforce.atlassian.net/browse/STAR-45

### Screenshots
<!-- if applicable -->
https://d.pr/v/YgRds0
https://d.pr/v/ysAdf7

### Types of changes
Improvement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
1. install/active  astra add on and enabled whileleble option
2. Add starter template details when enabled white lable.
3. IF agency link URL then you see the link on unlock access button
4. IF not link then  # on button link.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
