### PR TITLE
refactor: Astra's 4.0 dashboard app menu's position updated as per review

### DIFF
--- a/inc/classes/class-astra-sites-white-label.php
+++ b/inc/classes/class-astra-sites-white-label.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Astra_Sites_White_Label' ) ) :
 		/**
 		 * Update Astra's menu priority to show after Dashboard menu.
 		 *
-		 * @param int $menu_priority
+		 * @param int $menu_priority top level menu priority.
 		 * @since x.x.x
 		 */
 		public function update_admin_menu_position( $menu_priority ) {

--- a/inc/classes/class-astra-sites-white-label.php
+++ b/inc/classes/class-astra-sites-white-label.php
@@ -72,6 +72,9 @@ if ( ! class_exists( 'Astra_Sites_White_Label' ) ) :
 			add_filter( 'astra_sites_menu_page_title', array( $this, 'get_white_label_name' ) );
 			add_filter( 'astra_sites_page_title', array( $this, 'get_white_label_name' ) );
 
+			// Update Astra's admin top level menu position.
+			add_filter( 'astra_menu_priority', array( $this, 'update_admin_menu_position' ) );
+
 			// Display the link with the plugin meta.
 			if ( is_admin() ) {
 				add_filter( 'plugin_row_meta', array( $this, 'plugin_links' ), 10, 4 );
@@ -79,6 +82,17 @@ if ( ! class_exists( 'Astra_Sites_White_Label' ) ) :
 
 			add_filter( 'gutenberg_templates_localize_vars', array( $this, 'add_white_label_name' ) );
 		}
+
+		/**
+		 * Update Astra's menu priority to show after Dashboard menu.
+		 *
+		 * @param int $menu_priority
+		 * @since x.x.x
+		 */
+		public function update_admin_menu_position( $menu_priority ) {
+			return 2;
+		}
+
 		/**
 		 * Add White Label data
 		 *

--- a/inc/classes/class-astra-sites-white-label.php
+++ b/inc/classes/class-astra-sites-white-label.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'Astra_Sites_White_Label' ) ) :
 		 * @since x.x.x
 		 */
 		public function update_admin_menu_position( $menu_priority ) {
-			return 2;
+			return 2.1;
 		}
 
 		/**


### PR DESCRIPTION
### Description
- With Astra's 4.0 we are introducing new dashboard
- And as per review, we decided to update position of Astra toplevel menu position when ST plugin being activated

### Screenshots
- https://share.bsf.io/GGuJL6or

### Types of changes
- New feature (non-breaking change )

### How has this been tested?
- Check with Astra's 4.0 version
- Enable this ST plugin 
- Menu position should update from above appearance to next dahboard

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
